### PR TITLE
Minor script fixes

### DIFF
--- a/src/Agent.Listener/_project.json
+++ b/src/Agent.Listener/_project.json
@@ -32,7 +32,7 @@
     
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc3-23721",
-        "Microsoft.VisualStudio.Services.Agent": "",
+        "Microsoft.VisualStudio.Services.Agent": "*",
         "vss-api-netcore": "0.5.2-private",
         "Newtonsoft.Json": "7.0.1",
         "System.Diagnostics.TraceSource": "4.0.0-rc3-23721"

--- a/src/Agent.Worker/_project.json
+++ b/src/Agent.Worker/_project.json
@@ -31,7 +31,7 @@
     },
     
     "dependencies": {
-        "Microsoft.VisualStudio.Services.Agent": "",
+        "Microsoft.VisualStudio.Services.Agent": "*",
         "vss-api-netcore": "0.5.2-private",
         "System.Diagnostics.TraceSource": "4.0.0-rc3-23721",
         "System.Xml.XmlSerializer": "4.0.11-rc3-23721",

--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -1,1 +1,2 @@
-./bin/Agent.Listener $*
+script_dir=$(dirname $0)
+$script_dir/bin/Agent.Listener $*

--- a/src/Test/_project.json
+++ b/src/Test/_project.json
@@ -34,10 +34,10 @@
         "xunit.console.netcore": "1.0.2-prerelease-00101",
         "xunit.netcore.extensions": "1.0.0-prerelease-00153",
         "xunit.runner.utility": "2.1.0",
-        "Agent.Listener": { "target": "project" },
+        "Agent.Listener": { "target": "project", "version": "*" },
         "vss-api-netcore": "0.5.2-private",
-        "Microsoft.VisualStudio.Services.Agent": { "target": "project" },
-        "Agent.Worker": { "target": "project" } 
+        "Microsoft.VisualStudio.Services.Agent": { "target": "project", "version": "*" },
+        "Agent.Worker": { "target": "project", "version": "*" } 
     },
     "frameworks": {
         "dnxcore50": {


### PR DESCRIPTION
I am using centOS 7.1, without a specific version in the dependencies the restore is not working.

detailed configuration:
.NET Command Line Tools (1.0.0-beta-001661)

Product Information:
 Version:     1.0.0-beta-001661
 Commit Sha:  2b90a2f831

Runtime Environment:
 OS Name:     centos
 OS Version:  7
 OS Platform: Linux
 Runtime Id:  centos.7-x64

