### PR TITLE
Store the PATH environment variable

### DIFF
--- a/src/Agent.Listener/Configuration/LinuxServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/LinuxServiceControlManager.cs
@@ -50,11 +50,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 var unitContent = File.ReadAllText(Path.Combine(IOUtil.GetBinPath(), VstsAgentServiceTemplate));
                 var tokensToReplace = new Dictionary<string, string>
                                           {
-                                              { "{Description}", settings.ServiceDisplayName },
-                                              { "{BinDirectory}", IOUtil.GetBinPath() },
-                                              { "{AgentRoot}", IOUtil.GetRootPath() },
-                                              { "{ExternalsDirectory}", IOUtil.GetExternalsPath() },
-                                              { "{User}", GetCurrentLoginName() }
+                                              { "{{Description}}", settings.ServiceDisplayName },
+                                              { "{{BinDirectory}}", IOUtil.GetBinPath() },
+                                              { "{{AgentRoot}}", IOUtil.GetRootPath() },
+                                              { "{{ExternalsDirectory}}", IOUtil.GetExternalsPath() },
+                                              { "{{User}}", GetCurrentLoginName() },
+                                              { "{{Path}}", Environment.GetEnvironmentVariable("PATH") }
                                           };
 
                 unitContent = tokensToReplace.Aggregate(

--- a/src/Misc/layoutbin/vsts.agent.service.template
+++ b/src/Misc/layoutbin/vsts.agent.service.template
@@ -1,13 +1,13 @@
 [Unit]
-Description={Description}
+Description={{Description}}
 After=network.target
 
 [Service]
-ExecStart={ExternalsDirectory}/node/bin/node {BinDirectory}/AgentService.js
-User={User}
-Environment=PATH=/usr/bin:/usr/local/bin
+ExecStart={{ExternalsDirectory}}/node/bin/node {{BinDirectory}}/AgentService.js
+User={{User}}
+Environment=PATH={{Path}}
 Environment=NODE_ENV=production
-WorkingDirectory={AgentRoot}
+WorkingDirectory={{AgentRoot}}
 
 [Install]
 WantedBy=multi-user.target

--- a/src/Test/L0/Listener/Configuration/LinuxServiceControlManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/LinuxServiceControlManagerL0.cs
@@ -108,13 +108,13 @@ After=network.target
 [Service]
 ExecStart={0}/node/bin/node {1}/AgentService.js
 User={3}
-Environment=PATH=/usr/bin:/usr/local/bin
+Environment=PATH={4}
 Environment=NODE_ENV=production
 WorkingDirectory={2}
 
 [Install]
 WantedBy=multi-user.target
-", IOUtil.GetExternalsPath(), IOUtil.GetBinPath(), IOUtil.GetRootPath(), testUser);
+", IOUtil.GetExternalsPath(), IOUtil.GetBinPath(), IOUtil.GetRootPath(), testUser, Environment.GetEnvironmentVariable("PATH"));
 
                 var agentSettings = new AgentSettings
                                         {


### PR DESCRIPTION
Store the PATH environment variable during config and pass it to the linux service process. This improves capabilities detection (tools like "sh" were not detected prior this change). Tested the change on Ubuntu 16.04.