### PR TITLE
Preload Path env variable for OSX service

### DIFF
--- a/src/Misc/layoutbin/darwin.svc.sh.template
+++ b/src/Misc/layoutbin/darwin.svc.sh.template
@@ -36,7 +36,7 @@ function install()
     mkdir -p "${log_path}"
     chown "${USER}" "${log_path}"
 
-    sed "s/{{User}}/$USER/g; s/{{SvcName}}/$SVC_NAME/g; s@{{AgentRoot}}@${AGENT_ROOT}@g; s@{{UserHome}}@$HOME@g;" "${TEMPLATE_PATH}" > "${TEMP_PATH}" || failed "failed to create replacement temp file"
+    sed "s/{{PathVar}}/$(echo $PATH | sed -e 's/[\/&]/\\&/g')/g; s/{{User}}/$USER/g; s/{{SvcName}}/$SVC_NAME/g; s@{{AgentRoot}}@${AGENT_ROOT}@g; s@{{UserHome}}@$HOME@g;" "${TEMPLATE_PATH}" > "${TEMP_PATH}" || failed "failed to create replacement temp file"
     cp "${TEMP_PATH}" "${PLIST_PATH}" || "failed to copy plist"
 }
 

--- a/src/Misc/layoutbin/vsts.agent.plist.template
+++ b/src/Misc/layoutbin/vsts.agent.plist.template
@@ -23,6 +23,8 @@
     <string>{{UserHome}}/Library/Logs/{{SvcName}}/stdout.log</string>
     <key>EnvironmentVariables</key>
     <dict>
+      <key>PATH</key>
+      <string>{{PathVar}}</string>    
       <key>VSTS_AGENT_SVC</key>
       <string>1</string>
     </dict>


### PR DESCRIPTION
This is reading the Path variable during config and it is passing it to the OSX service (same as Linux service)
I tested with PATH containing spaces. To avoid issues with special characters recognized by "sed" as commands, I followed the suggestion on http://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern
