### PR TITLE
fix for service stop on OS X

### DIFF
--- a/src/Misc/layoutbin/runsvc.sh
+++ b/src/Misc/layoutbin/runsvc.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# convert SIGTERM signal to SIGINT
+trap 'kill -INT $PID' TERM INT
+
 if [ -f ".Path" ]; then
     # configure
     export PATH=`cat .Path`
@@ -9,4 +12,8 @@ fi
 # insert anything to setup env when running as a service
 
 # run the host process which keep the listener alive
-./externals/node/bin/node ./bin/AgentService.js
+./externals/node/bin/node ./bin/AgentService.js &
+PID=$!
+wait $PID
+trap - TERM INT
+wait $PID


### PR DESCRIPTION
convert SIGTERM signal to SIGINT in the bash script that runs the agent as a service. The coreclr agent can handle only SIGINT (SIGTERM not possible to handle in .Net Core for now).8