### PR TITLE
Remove NODE_ENV=production env var so npm behaves consistently on all platforms

### DIFF
--- a/src/Misc/layoutbin/vsts.agent.service.template
+++ b/src/Misc/layoutbin/vsts.agent.service.template
@@ -5,7 +5,6 @@ After=network.target
 [Service]
 ExecStart={{AgentRoot}}/runsvc.sh
 User={{User}}
-Environment=NODE_ENV=production
 WorkingDirectory={{AgentRoot}}
 KillMode=process
 KillSignal=SIGTERM

--- a/src/Test/L0/Listener/Configuration/LinuxServiceControlManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/LinuxServiceControlManagerL0.cs
@@ -106,7 +106,6 @@ After=network.target
 [Service]
 ExecStart={0}/runsvc.sh
 User={1}
-Environment=NODE_ENV=production
 WorkingDirectory={0}
 KillMode=process
 KillSignal=SIGTERM


### PR DESCRIPTION
Currently, for any npm tasks running on Linux agent, we will not pull any "devDependencies".  We are downloading "devDependencies" on both Windows and Mac.