### PR TITLE
The version of OS X El Capitan is 10.11 not 11.11

### DIFF
--- a/docs/preview/latebreaking.md
+++ b/docs/preview/latebreaking.md
@@ -8,7 +8,7 @@ Even though the agent has no pre-requisites, many of the tasks we run require Vi
 
 ## ![osx](../res/apple_med.png) OSX
 
-Tested on 10.10 (Yosemite) and 11.11 (El Capitan)
+Tested on 10.10 (Yosemite) and 10.11 (El Capitan)
 
 Update OpenSSL - [issue 110](https://github.com/Microsoft/vsts-agent/issues/110) 
 


### PR DESCRIPTION
I just upgraded my Mac Mini yesterday to El Capitan and when I check the version it reports 10.11.5.  I then searched to see if there was an 11.11 of El Capitan and there does not appear to be one.