### PR TITLE
add limited support for authenticated proxies using default credentials

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/WebProxy.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/WebProxy.cs
@@ -45,7 +45,10 @@ namespace Microsoft.VisualStudio.Services.Agent
                 return;
             }
             string proxyURI = File.ReadAllText(proxyFilePath);
-            VssHttpMessageHandler.DefaultWebProxy = new WebProxy(new Uri(proxyURI));
+            VssHttpMessageHandler.DefaultWebProxy = new WebProxy(new Uri(proxyURI))
+            {
+                Credentials = System.Net.CredentialCache.DefaultCredentials
+            };
         }
     }
 }


### PR DESCRIPTION
add limited support for authenticated proxies using default credentials, which is working only with proxies using Windows SSO.