### PR TITLE
Added sudo to svc.sh install

### DIFF
--- a/docs/start/nixsvc.md
+++ b/docs/start/nixsvc.md
@@ -14,7 +14,7 @@ Key Points:
 Install will create a LaunchAgent plist on OSX or a systemd unit file on Linux
 
 ```bash
-$ ./svc.sh install
+$ sudo ./svc.sh install
 ...
 Creating runsvc.sh
 Creating .Service


### PR DESCRIPTION
At least it was required for me that I svc.sh install with sudo, if it was added to all other commands, why not here too?

Otherwise I got the message: Path had bad ownership/permissions.


```
Maple-Mini:vsts-agent-osx.10.11-x64-2.102.0 alex$ ./svc.sh install
Creating launch agent in /Users/alex/Library/LaunchAgents/vsts.agent.sightplayer.Maple-Mini.plist
Creating /Users/alex/Library/Logs/vsts.agent.sightplayer.Maple-Mini
Creating /Users/alex/Library/LaunchAgents/vsts.agent.sightplayer.Maple-Mini.plist
Creating runsvc.sh
Creating .service
svc install complete
Maple-Mini:vsts-agent-osx.10.11-x64-2.102.0 alex$ sudo ./svc.sh start
starting vsts.agent.sightplayer.Maple-Mini
/Users/alex/Library/LaunchAgents/vsts.agent.sightplayer.Maple-Mini.plist: Path had bad ownership/permissions
status vsts.agent.sightplayer.Maple-Mini:

/Users/alex/Library/LaunchAgents/vsts.agent.sightplayer.Maple-Mini.plist

Stopped
```
