### PR TITLE
Add message indicating how to reconfigure the agent

### DIFF
--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -8,7 +8,7 @@
   "AgentMachinePoolNameLabel": "agent pool",
   "AgentName": "agent name",
   "AgentReplaced": "Successfully replaced the agent",
-  "AlreadyConfiguredError": "Cannot configure. Already configured.",
+  "AlreadyConfiguredError": "Cannot configure the agent because it is already configured. To reconfigure the agent, run 'config.cmd remove' or './config.sh remove' first.",
   "ArgumentNeeded": "'{0}' has to be specified.",
   "ArtifactCommandNotFound": "##vso[artifact.{0}] is not a recognized command for Artifact command extension. Please reference documentaion (http://go.microsoft.com/fwlink/?LinkId=817296)",
   "ArtifactLocationNotSupport": "Unsupport artifact location: {0}",


### PR DESCRIPTION
I was also at loss, just like described in #330, on how to reconfigure an agent once it was configured. The `Cannot configure. Already configured.` message did not indicate on how to reconfigure.

This PR updates the message to be actionable and provide a clear next step on how to reconfigure the agent.