### PR TITLE
Update NuGet.exe, add CredentialProvider.TeamBuild.exe (Dev15RC1)

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -137,7 +137,8 @@ if [[ "$PLATFORM" == "windows" ]]; then
     acquireExternalTool "$CONTAINER_URL/vstsom/m102_private_e90d775b/vstsom.zip" vstsom
     acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.exe" node/bin
     acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.lib" node/bin
-    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" nuget
+    acquireExternalTool "$CONTAINER_URL/NuGet/3.5.1-beta1-1621/NuGet.zip" nuget
+    acquireExternalTool "$CONTAINER_URL/CredentialProvider.TeamBuild/15.104.25518.0/CredentialProvider.TeamBuild.zip" nuget
 fi
 
 # Download the external tools only for OSX.


### PR DESCRIPTION
#423 ported to releases/dev15rc1

Not deploying to all platforms at this time because we're going to look in the system path for nuget on non-windows platforms again for now. We intend to revisit this later.