### PR TITLE
Port changes for result readers and add unit tests

### DIFF
--- a/src/Agent.Worker/TestResults/JunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/JunitResultReader.cs
@@ -58,6 +58,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 runUserIdRef = new IdentityRef() { DisplayName = runUser };
             }
 
+            var presentTime = DateTime.UtcNow;
+            runSummary.TimeStamp = DateTime.MaxValue;
+            var maxCompletedTime = DateTime.MinValue;
+
             //read data from testsuite nodes
 
             XmlNode testSuitesNode = doc.SelectSingleNode("testsuites");
@@ -69,11 +73,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     foreach (XmlNode testSuiteNode in testSuiteNodeList)
                     {
+                        //for each available suites get all suite details
                         TestSuiteSummary testSuiteSummary = ReadTestSuite(testSuiteNode, runUserIdRef);
-                        runSummary.Duration = runSummary.Duration.Add(testSuiteSummary.Duration);
-                        runSummary.Results.AddRange(testSuiteSummary.Results);
+
+                        // sum up testsuite durations and test case durations, decision on what to use will be taken later
+                        runSummary.TotalTestCaseDuration = runSummary.TotalTestCaseDuration.Add(testSuiteSummary.TotalTestCaseDuration);
+                        runSummary.TestSuiteDuration = runSummary.TestSuiteDuration.Add(testSuiteSummary.TestSuiteDuration);
+                        runSummary.SuiteTimeDataAvailable = runSummary.SuiteTimeDataAvailable && testSuiteSummary.SuiteTimeDataAvailable;
+                        runSummary.SuiteTimeStampAvailable = runSummary.SuiteTimeStampAvailable && testSuiteSummary.SuiteTimeStampAvailable;
                         runSummary.Host = testSuiteSummary.Host;
                         runSummary.Name = testSuiteSummary.Name;
+                        //stop calculating timestamp information, if timestamp data is not avilable for even one test suite
+                        if (testSuiteSummary.SuiteTimeStampAvailable)
+                        {
+                            runSummary.TimeStamp = runSummary.TimeStamp > testSuiteSummary.TimeStamp ? testSuiteSummary.TimeStamp : runSummary.TimeStamp;
+                            DateTime completedTime = testSuiteSummary.TimeStamp.AddTicks(testSuiteSummary.TestSuiteDuration.Ticks);
+                            maxCompletedTime = maxCompletedTime < completedTime ? completedTime : maxCompletedTime;
+                        }
+                        runSummary.Results.AddRange(testSuiteSummary.Results);
                     }
 
                     if (testSuiteNodeList.Count > 1)
@@ -84,10 +101,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             }
             else
             {
+                executionContext.Warning("Only single test suite found, parsing its information");
                 XmlNode testSuiteNode = doc.SelectSingleNode("testsuite");
                 if (testSuiteNode != null)
                 {
                     runSummary = ReadTestSuite(testSuiteNode, runUserIdRef);
+                    //only if start time is available then only we need to calculate completed time
+                    if (runSummary.TimeStamp != DateTime.MaxValue)
+                    {
+                        DateTime completedTime = runSummary.TimeStamp.AddTicks(runSummary.TestSuiteDuration.Ticks);
+                        maxCompletedTime = maxCompletedTime < completedTime ? completedTime : maxCompletedTime;
+                    }
+                    else
+                    {
+                        runSummary.SuiteTimeStampAvailable = false;
+                    }
                 }
             }
 
@@ -96,17 +124,29 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 runSummary.Name = runContext.RunName;
             }
 
-            if (runSummary.Results.Count > 0)
+            if (!runSummary.SuiteTimeStampAvailable)
             {
-                //first testsuite starteddate is the starteddate of the run
-                runSummary.TimeStamp = runSummary.Results[0].StartedDate;
+                executionContext.Output("Timestamp is not available for one or more testsuites. Total run duration is being calculated as the sum of time durations of detected testsuites");
+               
+                if (!runSummary.SuiteTimeDataAvailable)
+                {
+                    executionContext.Output("Time is not available for one or more testsuites. Total run duration is being calculated as the sum of time durations of detected testcases");
+                }
             }
-
+            //if start time is not calculated then it should be initialized as present time
+            runSummary.TimeStamp = runSummary.TimeStamp == DateTime.MaxValue 
+                ? presentTime 
+                : runSummary.TimeStamp;
+            //if suite timestamp data is not available even for single testsuite, then fallback to testsuite run time
+            //if testsuite run time is not available even for single testsuite, then fallback to total test case duration
+            maxCompletedTime = !runSummary.SuiteTimeStampAvailable || maxCompletedTime == DateTime.MinValue 
+                ? runSummary.TimeStamp.Add(runSummary.SuiteTimeDataAvailable ? runSummary.TestSuiteDuration 
+                : runSummary.TotalTestCaseDuration) : maxCompletedTime;
             //create test run data
             var testRunData = new TestRunData(
                 name: runSummary.Name,
                 startedDate: runSummary.TimeStamp.ToString("o"),
-                completedDate: runSummary.TimeStamp.Add(runSummary.Duration).ToString("o"),
+                completedDate: maxCompletedTime.ToString("o"),
                 state: TestRunState.InProgress.ToString(),
                 isAutomated: true,
                 buildId: runContext != null ? runContext.BuildId : 0,
@@ -155,15 +195,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             XmlAttribute timestampNode = rootNode.Attributes["timestamp"];
             if (timestampNode != null && timestampNode.Value != null)
             {
-                if (DateTime.TryParse(timestampNode.Value, out timestampFromXml))
+                if (DateTime.TryParse(timestampNode.Value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None, out timestampFromXml))
                 {
                     testSuiteSummary.TimeStamp = timestampFromXml;
                 }
             }
 
-            totalTestSuiteDuration = GetTimeSpan(rootNode);
+            if (timestampFromXml == DateTime.MinValue)
+            {
+                testSuiteSummary.SuiteTimeStampAvailable = false;
+            }
 
-            DateTime testSuiteStartTime = testSuiteSummary.TimeStamp;
+            bool SuiteTimeDataAvailable = false;
+            totalTestSuiteDuration = GetTimeSpan(rootNode, out SuiteTimeDataAvailable);
+            testSuiteSummary.SuiteTimeDataAvailable = SuiteTimeDataAvailable;
+
+            var testSuiteStartTime = testSuiteSummary.TimeStamp;
 
             //find test case nodes in JUnit result xml
             XmlNodeList testCaseNodes = rootNode.SelectNodes("./testcase");
@@ -189,7 +236,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     }
 
                     //test case duration
-                    TimeSpan testCaseDuration = GetTimeSpan(testCaseNode);
+                    bool TestCaseTimeDataAvailable = false;
+                    var testCaseDuration = GetTimeSpan(testCaseNode, out TestCaseTimeDataAvailable);
+                    totalTestCaseDuration = totalTestCaseDuration + testCaseDuration;
                     resultCreateModel.DurationInMs = testCaseDuration.TotalMilliseconds;
 
                     resultCreateModel.StartedDate = testCaseStartTime;
@@ -241,27 +290,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 }
             }
 
-            if (TimeSpan.Compare(totalTestSuiteDuration, totalTestCaseDuration) < 0)
-            {
-                totalTestSuiteDuration = totalTestCaseDuration; //run duration may not be set in the xml, so use total test case duration 
-            }
-            testSuiteSummary.Duration = totalTestSuiteDuration;
+            testSuiteSummary.TestSuiteDuration = totalTestSuiteDuration;
+            testSuiteSummary.TotalTestCaseDuration = totalTestCaseDuration;
 
             return testSuiteSummary;
         }
 
-        private TimeSpan GetTimeSpan(XmlNode rootNode)
+        private static TimeSpan GetTimeSpan(XmlNode rootNode, out bool TimeDataAvailable)
         {
             var time = TimeSpan.Zero;
+            TimeDataAvailable = false;
             if (rootNode.Attributes["time"] != null)
             {
                 var timeValue = rootNode.Attributes["time"].Value;
                 if (timeValue != null)
                 {
                     double timeInSeconds = 0.0;
-                    if (double.TryParse(timeValue, out timeInSeconds))
+                    if (Double.TryParse(timeValue, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out timeInSeconds))
                     {
                         time = TimeSpan.FromSeconds(timeInSeconds);
+                        TimeDataAvailable = true;
                     }
                 }
             }
@@ -291,17 +339,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
             public DateTime TimeStamp { get; set; }
 
-            public TimeSpan Duration { get; set; }
+            public TimeSpan TestSuiteDuration { get; set; }
 
             public List<TestCaseResultData> Results { get; set; }
+
+            public TimeSpan TotalTestCaseDuration { get; set; }
+            
+            public bool SuiteTimeDataAvailable { get; set; }
+            
+            public bool SuiteTimeStampAvailable { get; set; }
 
             public TestSuiteSummary(string name)
             {
                 Name = name;
                 Host = string.Empty;
                 TimeStamp = DateTime.Now;
-                Duration = TimeSpan.Zero;
+                TestSuiteDuration = TimeSpan.Zero;
+                SuiteTimeDataAvailable = true;
+                SuiteTimeStampAvailable = true;
                 Results = new List<TestCaseResultData>();
+                TotalTestCaseDuration = TimeSpan.Zero;
             }
         }
     }

--- a/src/Agent.Worker/TestResults/JunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/JunitResultReader.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             }
             else
             {
-                executionContext.Warning("Only single test suite found, parsing its information");
+                executionContext.Output("Only single test suite found, parsing its information");
                 XmlNode testSuiteNode = doc.SelectSingleNode("testsuite");
                 if (testSuiteNode != null)
                 {
@@ -240,7 +240,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     var testCaseDuration = GetTimeSpan(testCaseNode, out TestCaseTimeDataAvailable);
                     totalTestCaseDuration = totalTestCaseDuration + testCaseDuration;
                     resultCreateModel.DurationInMs = testCaseDuration.TotalMilliseconds;
-
                     resultCreateModel.StartedDate = testCaseStartTime;
                     resultCreateModel.CompletedDate = testCaseStartTime.AddTicks(testCaseDuration.Ticks);
                     testCaseStartTime = testCaseStartTime.AddTicks(1) + testCaseDuration; //next start time

--- a/src/Agent.Worker/TestResults/NunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/NunitResultReader.cs
@@ -60,13 +60,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 DateTime dateFromXml = DateTime.MinValue.Date; //Use local time instead of UTC as TestRunData uses local time for defaults.
                 if (testResultsNode.Attributes["date"] != null)
                 {
-                    DateTime.TryParse(testResultsNode.Attributes["date"].Value, out dateFromXml);
+                    DateTime.TryParse(testResultsNode.Attributes["date"].Value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None, out dateFromXml);
                 }
 
                 TimeSpan timeFromXml = TimeSpan.Zero;
                 if (testResultsNode.Attributes["time"] != null)
                 {
-                    TimeSpan.TryParse(testResultsNode.Attributes["time"].Value, out timeFromXml);
+                    TimeSpan.TryParse(testResultsNode.Attributes["time"].Value, CultureInfo.InvariantCulture, out timeFromXml);
                 }
 
                 //assume runtimes from xml are current local time since timezone information is not in the xml, if xml datetime > current local time, fallback to local start time
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     if (testCaseNode.Attributes["time"] != null && testCaseNode.Attributes["time"].Value != null)
                     {
                         double duration = 0;
-                        double.TryParse(testCaseNode.Attributes["time"].Value, out duration);
+                        double.TryParse(testCaseNode.Attributes["time"].Value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out duration);
                         testCaseDuration = TimeSpan.FromSeconds(duration);
                     }
                     resultCreateModel.DurationInMs = testCaseDuration.TotalMilliseconds;

--- a/src/Agent.Worker/TestResults/TrxResultReader.cs
+++ b/src/Agent.Worker/TestResults/TrxResultReader.cs
@@ -75,11 +75,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             DateTime runFinishDate = DateTime.MinValue;
             if (node != null && node.Attributes["start"] != null && node.Attributes["finish"] != null)
             {
-                if (DateTime.TryParse(node.Attributes["start"].Value, out runStartDate))
+                if (DateTime.TryParse(node.Attributes["start"].Value, DateTimeFormatInfo.InvariantInfo,DateTimeStyles.None, out runStartDate))
                 {
                     _executionContext.Debug(string.Format(CultureInfo.InvariantCulture, "Setting run start and finish times."));
                     //Only if there is a valid start date.
-                    DateTime.TryParse(node.Attributes["finish"].Value, out runFinishDate);
+                    DateTime.TryParse(node.Attributes["finish"].Value, DateTimeFormatInfo.InvariantInfo,DateTimeStyles.None, out runFinishDate);
                     if (runFinishDate < runStartDate)
                     {
                         runFinishDate = runStartDate = DateTime.MinValue;
@@ -264,7 +264,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 TimeSpan duration;
                 if (resultNode.Attributes["duration"] != null && resultNode.Attributes["duration"].Value != null)
                 {
-                    TimeSpan.TryParse(resultNode.Attributes["duration"].Value, out duration);
+                    TimeSpan.TryParse(resultNode.Attributes["duration"].Value, CultureInfo.InvariantCulture, out duration);
                 }
                 else
                 {
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 DateTime startedDate;
                 if (resultNode.Attributes["startTime"] != null && resultNode.Attributes["startTime"].Value != null)
                 {
-                    DateTime.TryParse(resultNode.Attributes["startTime"].Value, out startedDate);
+                    DateTime.TryParse(resultNode.Attributes["startTime"].Value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None, out startedDate);
                 }
                 else
                 {

--- a/src/Agent.Worker/TestResults/XunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/XunitResultReader.cs
@@ -89,16 +89,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                         dateTimeParseError = false;
                     }
                     assemblyRunStartTimeStamp = startDate + startTime;
-					if(minStartTime > assemblyRunStartTimeStamp)
-					{
-						minStartTime = assemblyRunStartTimeStamp;
-					}
+                    if (minStartTime > assemblyRunStartTimeStamp)
+                    {
+                        minStartTime = assemblyRunStartTimeStamp;
+                    }
                 }
-				else 
-				{
-					assemblyRunDateTimeAttributesNotPresent = true;
-				}
-				if (!assemblyTimeAttributeNotPresent && assemblyNode.Attributes["time"] != null)
+                else 
+                {
+                    assemblyRunDateTimeAttributesNotPresent = true;
+                }
+                if (!assemblyTimeAttributeNotPresent && assemblyNode.Attributes["time"] != null)
                 {
                     double assemblyDuration = 0;
                     Double.TryParse(assemblyNode.Attributes["time"].Value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out assemblyDuration);
@@ -229,7 +229,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     }
                 }
             }
-			if (dateTimeParseError || assemblyRunDateTimeAttributesNotPresent)
+            if (dateTimeParseError || assemblyRunDateTimeAttributesNotPresent)
             {
                 executionContext.Warning("Atleast for one assembly start time was not obtained due to tag not present or parsing issue, total run duration will now be summation of time taken by each assembly");
 

--- a/src/Test/L0/Worker/TestResults/JunitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/JunitResultReaderTests.cs
@@ -375,7 +375,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             var testCase1CompletedDate = _testRunData.Results[0].CompletedDate;
             var testCase2StartDate = _testRunData.Results[1].StartedDate;
             Assert.True(testCase1CompletedDate <= testCase2StartDate, "first test case end should be before second test case start time");
-
         }
 
         [Fact]

--- a/src/Test/L0/Worker/TestResults/TrxResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/TrxResultReaderTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Worker;
 using Microsoft.VisualStudio.Services.Agent.Worker.TestResults;
 using Moq;
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
@@ -218,6 +220,132 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "PublishTestResults")]
+        public void ReadsResultsReturnsCorrectValuesInDifferentCulture()
+        {
+            SetupMocks();
+            CultureInfo current = CultureInfo.CurrentCulture;
+            try
+            {
+                //German is used, as in this culture decimal seperator is comma & thousand seperator is dot
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+                String trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
+               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+
+                 "<TestDefinitions>" +
+                   "<UnitTest name = \"TestMethod2\" storage = \"c:/users/kaadhina/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"c:/users/kaadhina/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                   "<WebTest name=\"PSD_Startseite\" storage=\"c:\\vsoagent\\a284d2cc\\vseqa1\\psd_startseite.webtest\" id=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" persistedWebTest=\"7\"><TestCategory><TestCategoryItem TestCategory=\"PSD\" /></TestCategory><Execution id=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" /></WebTest>" +
+                 "</TestDefinitions>" +
+
+                 "<TestSettings name=\"TestSettings1\" id=\"e9d264e9-30da-48df-aa95-c6b53f699464\"><Description>These are default test settings for a local test run.</Description>" +
+                   "<Execution>" +
+                     "<AgentRule name=\"LocalMachineDefaultRole\">" +
+                       "<DataCollectors>" +
+                         "<DataCollector uri=\"datacollector://microsoft/CodeCoverage/1.0\" assemblyQualifiedName=\"Microsoft.VisualStudio.TestTools.CodeCoverage.CoveragePlugIn, Microsoft.VisualStudio.QualityTools.Plugins.CodeCoverage, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\" friendlyName=\"Code Coverage (Visual Studio 2010)\">" +
+                           "<Configuration><CodeCoverage xmlns=\"\"><Regular>" +
+                             "<CodeCoverageItem binaryFile=\"C:\\mstest.static.UnitTestProject3.dll\" pdbFile=\"C:\\mstest.static.UnitTestProject3.instr.pdb\" instrumentInPlace=\"true\" />" +
+                           "</Regular></CodeCoverage></Configuration>" +
+                         "</DataCollector>" +
+                       "</DataCollectors>" +
+                     "</AgentRule>" +
+                   "</Execution>" +
+                 "</TestSettings>" +
+
+                 "<Results>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                     "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
+                   "</UnitTestResult>" +
+
+                   "<WebTestResult executionId=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" testId=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" testName=\"PSD_Startseite\" computerName=\"LAB-BUILDVNEXT\" duration=\"00:00:01.6887389\" startTime=\"2015-05-20T18:53:51.1063165+00:00\" endTime=\"2015-05-20T18:54:03.9160742+00:00\" testType=\"4e7599fa-5ecb-43e9-a887-cd63cf72d207\" outcome=\"Passed\" testListId=\"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory=\"eb421c16-4546-435a-9c24-0d2878ea76d4\"><Output><StdOut>Do not show console log output.</StdOut></Output>" +
+                     "<ResultFiles>" +
+                       "<ResultFile path=\"PSD_Startseite.webtestResult\" />" +
+                     "</ResultFiles>" +
+                     "<WebTestResultFilePath>LOCAL SERVICE_LAB-BUILDVNEXT 2015-05-20 18_53_41\\In\\eb421c16-4546-435a-9c24-0d2878ea76d4\\PSD_Startseite.webtestResult</WebTestResultFilePath>" +
+                   "</WebTestResult>" +
+                 "</Results>" +
+
+                 "<ResultSummary outcome=\"Failed\"><Counters total = \"2\" executed = \"2\" passed=\"1\" failed=\"1\" error=\"0\" timeout=\"0\" aborted=\"0\" inconclusive=\"0\" passedButRunAborted=\"0\" notRunnable=\"0\" notExecuted=\"0\" disconnected=\"0\" warning=\"0\" completed=\"0\" inProgress=\"0\" pending=\"0\" />" +
+
+                   "<CollectorDataEntries>" +
+                     "<Collector agentName=\"DIGANR-DEV4\" uri=\"datacollector://microsoft/CodeCoverage/2.0\" collectorDisplayName=\"Code Coverage\"><UriAttachments><UriAttachment>" +
+                       "<A href=\"DIGANR-DEV4\\vstest_console.dynamic.data.coverage\"></A></UriAttachment></UriAttachments>" +
+                     "</Collector>" +
+                     "<Collector agentName=\"DIGANR-DEV4\" uri=\"datacollector://microsoft/CodeCoverage/1.0\" collectorDisplayName=\"MSTestAdapter\"><UriAttachments>" +
+                       "<UriAttachment><A href=\"DIGANR-DEV4\\unittestproject3.dll\">c:\\vstest.static.unittestproject3.dll</A></UriAttachment>" +
+                       "<UriAttachment><A href=\"DIGANR-DEV4\\UnitTestProject3.instr.pdb\">C:\\vstest.static.UnitTestProject3.instr.pdb</A></UriAttachment>" +
+                     "</UriAttachments></Collector>" +
+                   "</CollectorDataEntries>" +
+
+                   "<ResultFiles>" +
+                     "<ResultFile path=\"vstest_console.static.data.coverage\" /></ResultFiles>" +
+                     "<ResultFile path=\"DIGANR-DEV4\\mstest.static.data.coverage\" />" +
+                   "</ResultSummary>" +
+
+               "</TestRun>";
+
+                var runData = GetTestRunData(trxContents, null, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+                DateTime StartedDate;
+                DateTime.TryParse("2015-03-20T16:53:32.3099353+05:30", out StartedDate);
+                Assert.Equal(runData.Results[0].StartedDate, StartedDate);
+
+                TimeSpan Duration;
+                TimeSpan.TryParse("00:00:00.0834563", out Duration);
+                Assert.Equal(runData.Results[0].DurationInMs, Duration.TotalMilliseconds);
+
+                DateTime CompletedDate = StartedDate.AddTicks(Duration.Ticks);
+                Assert.Equal(runData.Results[0].CompletedDate, CompletedDate);
+
+                Assert.Equal(runData.Name, "VSTest Test Run debug any cpu");
+                Assert.Equal(runData.State, "InProgress");
+                Assert.Equal(runData.Results.Length, 2);
+
+                Assert.Equal(runData.Results[0].Outcome, "Failed");
+                Assert.Equal(runData.Results[0].TestCaseTitle, "TestMethod2");
+                Assert.Equal(runData.Results[0].ComputerName, "KAADHINA1");
+                Assert.Equal(runData.Results[0].AutomatedTestType, "UnitTest");
+                Assert.Equal(runData.Results[0].AutomatedTestName, "UnitTestProject4.UnitTest1.TestMethod2");
+                Assert.Equal(runData.Results[0].AutomatedTestId, "f0d6b58f-dc08-9c0b-aab7-0a1411d4a346");
+                Assert.Equal(runData.Results[0].AutomatedTestStorage, "unittestproject4.dll");
+                Assert.Equal(runData.Results[0].AutomatedTestTypeId, "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b");
+                Assert.Equal(runData.Results[0].ErrorMessage, "Assert.Fail failed.");
+                Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
+                Assert.Equal(runData.Results[0].Priority.ToString(), "1");
+                Assert.Equal(runData.Results[0].ConsoleLog, "Show console log output.");
+                Assert.Equal(runData.Results[0].Attachments.Length, 1);
+                Assert.True(runData.Results[0].Attachments[0].Contains("x.txt"));
+
+                Assert.Equal(runData.Results[1].Outcome, "Passed");
+                Assert.Equal(runData.Results[1].TestCaseTitle, "PSD_Startseite");
+                Assert.Equal(runData.Results[1].ComputerName, "LAB-BUILDVNEXT");
+                Assert.Equal(runData.Results[1].AutomatedTestType, "WebTest");
+                Assert.Equal(runData.Results[1].ConsoleLog, null);
+                Assert.Equal(runData.Results[1].Attachments.Length, 1);
+                Assert.True(runData.Results[1].Attachments[0].Contains("PSD_Startseite.webtestResult"));
+
+                Assert.Equal(runData.BuildFlavor, "debug");
+                Assert.Equal(runData.BuildPlatform, "any cpu");
+                // 3 files related mstest.static, 3 files related to vstest.static, and 1 file for vstest.dynamic 
+                Assert.Equal(runData.Attachments.Length, 7);
+
+                int buildId;
+                int.TryParse(runData.Build.Id, out buildId);
+                Assert.Equal(buildId, 1);
+
+                Assert.Equal(runData.ReleaseUri, "releaseUri");
+                Assert.Equal(runData.ReleaseEnvironmentUri, "releaseEnvironmentUri");
+
+
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = current;
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
         public void CustomRunTitleIsHonoured()
         {
             SetupMocks();
@@ -421,7 +549,50 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             var runData = GetTestRunDataWithAttachments(0);
             Assert.Equal("unittest".ToLowerInvariant(), runData.Results[0].AutomatedTestType.ToLowerInvariant());
         }
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category","PublishTestResults")]
+        public void VerifyReadResultsReturnsCorrectTestStartAndEndDateTime()
+        {
+            SetupMocks();
+            String trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
+               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
 
+                 "<TestDefinitions>" +
+                   "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\kaadhina\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                   "<WebTest name=\"PSD_Startseite\" storage=\"c:\\vsoagent\\a284d2cc\\vseqa1\\psd_startseite.webtest\" id=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" persistedWebTest=\"7\"><TestCategory><TestCategoryItem TestCategory=\"PSD\" /></TestCategory><Execution id=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" /></WebTest>" +
+                 "</TestDefinitions>" +
+
+                 "<Results>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                     "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
+                   "</UnitTestResult>" +
+
+                   "<WebTestResult executionId=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" testId=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" testName=\"PSD_Startseite\" computerName=\"LAB-BUILDVNEXT\" duration=\"00:00:01.6887389\" startTime=\"2015-05-20T18:53:51.1063165+00:00\" endTime=\"2015-05-20T18:54:03.9160742+00:00\" testType=\"4e7599fa-5ecb-43e9-a887-cd63cf72d207\" outcome=\"Passed\" testListId=\"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory=\"eb421c16-4546-435a-9c24-0d2878ea76d4\"><Output><StdOut>Do not show console log output.</StdOut></Output>" +
+                     "<ResultFiles>" +
+                       "<ResultFile path=\"PSD_Startseite.webtestResult\" />" +
+                     "</ResultFiles>" +
+                     "<WebTestResultFilePath>LOCAL SERVICE_LAB-BUILDVNEXT 2015-05-20 18_53_41\\In\\eb421c16-4546-435a-9c24-0d2878ea76d4\\PSD_Startseite.webtestResult</WebTestResultFilePath>" +
+                   "</WebTestResult>" +
+                 "</Results>" +
+
+                 "<ResultSummary outcome=\"Failed\"><Counters total = \"2\" executed = \"2\" passed=\"1\" failed=\"1\" error=\"0\" timeout=\"0\" aborted=\"0\" inconclusive=\"0\" passedButRunAborted=\"0\" notRunnable=\"0\" notExecuted=\"0\" disconnected=\"0\" warning=\"0\" completed=\"0\" inProgress=\"0\" pending=\"0\" />" +
+                   "<ResultFiles>" +
+                     "<ResultFile path=\"vstest_console.static.data.coverage\" /></ResultFiles>" +
+                   "</ResultSummary>" +
+
+               "</TestRun>";
+
+            var runData = GetTestRunData(trxContents, null, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+            DateTime StartedDate;
+            DateTime.TryParse("2015-03-20T16:53:32.3349628+05:30", out StartedDate);
+            Assert.Equal(runData.StartDate, StartedDate.ToString("o"));
+
+            DateTime CompletedDate;
+            DateTime.TryParse("2015-03-20T16:53:32.9232329+05:30", out CompletedDate);
+            Assert.Equal(runData.CompleteDate, CompletedDate.ToString("o"));
+        }
         public void Dispose()
         {
             try

--- a/src/Test/L0/Worker/TestResults/TrxResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/TrxResultReaderTests.cs
@@ -4,9 +4,9 @@ using Microsoft.VisualStudio.Services.Agent.Worker.TestResults;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Globalization;
 using System.Threading;
 using Xunit;
 
@@ -53,13 +53,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             String trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
-               "<TestRun id = \"asdf\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+               "<TestRun id = \"asdf\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
 
                  "<TestDefinitions>" +
-                   "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\kaadhina\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"asdf\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"asdf\" /><TestMethod codeBase = \"C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                   "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\somerandomusername\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"asdf\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"asdf\" /><TestMethod codeBase = \"C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
                  "</TestDefinitions>" +
                   "<Results>" +
-                   "<UnitTestResult executionId = \"asdf\" testId = \"asdf\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"asfd\" outcome = \"Failed\" testListId = \"asdf\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                   "<UnitTestResult executionId = \"asdf\" testId = \"asdf\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"asfd\" outcome = \"Failed\" testListId = \"asdf\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                      "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                    "</UnitTestResult>" +
                    "</Results></TestRun>";
@@ -111,10 +111,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             String trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
-               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
 
                  "<TestDefinitions>" +
-                   "<UnitTest name = \"TestMethod2\" storage = \"c:/users/kaadhina/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"c:/users/kaadhina/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                   "<UnitTest name = \"TestMethod2\" storage = \"c:/users/somerandomusername/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"c:/users/somerandomusername/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
                    "<WebTest name=\"PSD_Startseite\" storage=\"c:\\vsoagent\\a284d2cc\\vseqa1\\psd_startseite.webtest\" id=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" persistedWebTest=\"7\"><TestCategory><TestCategoryItem TestCategory=\"PSD\" /></TestCategory><Execution id=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" /></WebTest>" +
                  "</TestDefinitions>" +
 
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                  "</TestSettings>" +
 
                  "<Results>" +
-                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                      "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                    "</UnitTestResult>" +
 
@@ -183,14 +183,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
             Assert.Equal(runData.Results[0].Outcome, "Failed");
             Assert.Equal(runData.Results[0].TestCaseTitle, "TestMethod2");
-            Assert.Equal(runData.Results[0].ComputerName, "KAADHINA1");
+            Assert.Equal(runData.Results[0].ComputerName, "SOMERANDOMCOMPUTERNAME");
             Assert.Equal(runData.Results[0].AutomatedTestType, "UnitTest");
             Assert.Equal(runData.Results[0].AutomatedTestName, "UnitTestProject4.UnitTest1.TestMethod2");
             Assert.Equal(runData.Results[0].AutomatedTestId, "f0d6b58f-dc08-9c0b-aab7-0a1411d4a346");
             Assert.Equal(runData.Results[0].AutomatedTestStorage, "unittestproject4.dll");
             Assert.Equal(runData.Results[0].AutomatedTestTypeId, "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b");
             Assert.Equal(runData.Results[0].ErrorMessage, "Assert.Fail failed.");
-            Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
+            Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
             Assert.Equal(runData.Results[0].Priority.ToString(), "1");
             Assert.Equal(runData.Results[0].ConsoleLog, "Show console log output.");
             Assert.Equal(runData.Results[0].Attachments.Length, 1);
@@ -230,10 +230,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                 CultureInfo.CurrentCulture = new CultureInfo("de-DE");
 
                 String trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
-               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
 
                  "<TestDefinitions>" +
-                   "<UnitTest name = \"TestMethod2\" storage = \"c:/users/kaadhina/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"c:/users/kaadhina/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                   "<UnitTest name = \"TestMethod2\" storage = \"c:/users/somerandomusername/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"c:/users/somerandomusername/source/repos/projectx/unittestproject4/unittestproject4/bin/debug/unittestproject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
                    "<WebTest name=\"PSD_Startseite\" storage=\"c:\\vsoagent\\a284d2cc\\vseqa1\\psd_startseite.webtest\" id=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" persistedWebTest=\"7\"><TestCategory><TestCategoryItem TestCategory=\"PSD\" /></TestCategory><Execution id=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" /></WebTest>" +
                  "</TestDefinitions>" +
 
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                  "</TestSettings>" +
 
                  "<Results>" +
-                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                      "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                    "</UnitTestResult>" +
 
@@ -302,14 +302,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
                 Assert.Equal(runData.Results[0].Outcome, "Failed");
                 Assert.Equal(runData.Results[0].TestCaseTitle, "TestMethod2");
-                Assert.Equal(runData.Results[0].ComputerName, "KAADHINA1");
+                Assert.Equal(runData.Results[0].ComputerName, "SOMERANDOMCOMPUTERNAME");
                 Assert.Equal(runData.Results[0].AutomatedTestType, "UnitTest");
                 Assert.Equal(runData.Results[0].AutomatedTestName, "UnitTestProject4.UnitTest1.TestMethod2");
                 Assert.Equal(runData.Results[0].AutomatedTestId, "f0d6b58f-dc08-9c0b-aab7-0a1411d4a346");
                 Assert.Equal(runData.Results[0].AutomatedTestStorage, "unittestproject4.dll");
                 Assert.Equal(runData.Results[0].AutomatedTestTypeId, "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b");
                 Assert.Equal(runData.Results[0].ErrorMessage, "Assert.Fail failed.");
-                Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
+                Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
                 Assert.Equal(runData.Results[0].Priority.ToString(), "1");
                 Assert.Equal(runData.Results[0].ConsoleLog, "Show console log output.");
                 Assert.Equal(runData.Results[0].Attachments.Length, 1);
@@ -334,8 +334,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
                 Assert.Equal(runData.ReleaseUri, "releaseUri");
                 Assert.Equal(runData.ReleaseEnvironmentUri, "releaseEnvironmentUri");
-
-
             }
             finally
             {
@@ -402,7 +400,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             string trxContents = "<?xml version =\"1.0\" encoding=\"UTF-8\"?>" +
-                "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+                "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
                 "<Results>" +
                 "<UnitTestResult testId=\"fd1a9d66-d059-cd84-23d7-f655dce255f5\" testName=\"TestMethod1\" outcome=\"Passed\" />" +
                 "</Results>" +
@@ -427,7 +425,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             string trxContents = "<?xml version =\"1.0\" encoding=\"UTF-8\"?>" +
-                "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" />" +
+                "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" />" +
                 "<Results>" +
                 "<UnitTestResult testId=\"fd1a9d66-d059-cd84-23d7-f655dce255f5\" testName=\"TestMethod1\" outcome=\"Passed\" />" +
                 "</Results>" +
@@ -496,7 +494,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             Assert.Equal(3, runData.Attachments.Length);
         }
 
-
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "PublishTestResults")]
@@ -556,15 +553,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             String trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
-               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+               "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
 
                  "<TestDefinitions>" +
-                   "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\kaadhina\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                   "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\somerandomusername\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
                    "<WebTest name=\"PSD_Startseite\" storage=\"c:\\vsoagent\\a284d2cc\\vseqa1\\psd_startseite.webtest\" id=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" persistedWebTest=\"7\"><TestCategory><TestCategoryItem TestCategory=\"PSD\" /></TestCategory><Execution id=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" /></WebTest>" +
                  "</TestDefinitions>" +
 
                  "<Results>" +
-                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                      "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                    "</UnitTestResult>" +
 
@@ -607,7 +604,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         private TestRunData GetTestRunDataBasic(TrxResultReader myReader = null)
         {
             string trxContents = "<?xml version =\"1.0\" encoding=\"UTF-8\"?>" +
-                                 "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2014-03-20T16:53:32.3349628+05:30\" />" +
+                                 "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2014-03-20T16:53:32.3349628+05:30\" />" +
                                  "<Results>" +
                                  "<UnitTestResult testId=\"fd1a9d66-d059-cd84-23d7-f655dce255f5\" testName=\"TestMethod1\" outcome=\"Passed\" />" +
                                  "</Results>" +
@@ -624,10 +621,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         private TestRunData GetTestRunDataWithAttachments(int val, TrxResultReader myReader = null, TestRunContext trContext = null)
         {
             var trxContents = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>" +
-              "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"kaadhina@KAADHINA1 2015-03-20 16:53:32\" runUser = \"FAREAST\\kaadhina\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
+              "<TestRun id = \"ee3d8b3b-1ac9-4a7e-abfa-3d3ed2008613\" name = \"somerandomusername@SOMERANDOMCOMPUTERNAME 2015-03-20 16:53:32\" runUser = \"FAREAST\\somerandomusername\" xmlns =\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"><Times creation = \"2015-03-20T16:53:32.3309380+05:30\" queuing = \"2015-03-20T16:53:32.3319381+05:30\" start = \"2015-03-20T16:53:32.3349628+05:30\" finish = \"2015-03-20T16:53:32.9232329+05:30\" />" +
 
                 "<TestDefinitions>" +
-                  "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\kaadhina\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
+                  "<UnitTest name = \"TestMethod2\" storage = \"c:\\users\\somerandomusername\\source\\repos\\projectx\\unittestproject4\\unittestproject4\\bin\\debug\\unittestproject4.dll\" priority = \"1\" id = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\"><Owners><Owner name = \"asdf2\" /></Owners><Execution id = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" /><TestMethod codeBase = \"C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\bin\\Debug\\UnitTestProject4.dll\" adapterTypeName = \"Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter\" className = \"UnitTestProject4.UnitTest1\" name = \"TestMethod2\" /></UnitTest>" +
                   "<WebTest name=\"PSD_Startseite\" storage=\"c:\\vsoagent\\a284d2cc\\vseqa1\\psd_startseite.webtest\" id=\"01da1a13-b160-4ee6-9d84-7a6dfe37b1d2\" persistedWebTest=\"7\"><TestCategory><TestCategoryItem TestCategory=\"PSD\" /></TestCategory><Execution id=\"eb421c16-4546-435a-9c24-0d2878ea76d4\" /></WebTest>" +
                 "</TestDefinitions>" +
 
@@ -645,7 +642,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                   "</Execution>" +
                 "</TestSettings>" +
 
-
                 "{0}" +
                 "{1}" +
 
@@ -657,7 +653,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
               "</TestRun>";
 
             var part0 = "<Results>" +
-                  "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"KAADHINA1\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\kaadhina\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                  "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                     "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                   "</UnitTestResult>" +
 

--- a/src/Test/L0/Worker/TestResults/XUnitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/XUnitResultReaderTests.cs
@@ -4,10 +4,10 @@ using Microsoft.VisualStudio.Services.Agent.Worker.TestResults;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Globalization;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
         private const string _xunitResultsFull = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<assemblies>" +
-        "<assembly name=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
+        "<assembly name=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
         "<errors />" +
         "<collection total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class1\" time=\"0.044\">" +
         "<test name=\"MyFirstUnitTests.Class1.FailingTest\" type=\"MyFirstUnitTests.Class1\" method=\"FailingTest\" time=\"0.0422319\" result=\"Fail\">" +
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         "<message><![CDATA[Assert.Equal() Failure" +
         "Expected: 5" +
         "Actual: 4]]></message >" +
-        "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
+        "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
         "</failure >" +
         "</test>" +
         "<test name=\"MyFirstUnitTests.Class1.PassingTest\" type=\"MyFirstUnitTests.Class1\" method=\"PassingTest\" time=\"0.0014079\" result=\"Pass\">" +
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         "</test>" +
         "</collection>" +
         "</assembly>" +
-        "<assembly name=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
+        "<assembly name=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
         "<errors />" +
         "<collection total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class2\" time=\"0.006\">" +
         "<test name=\"MyFirstUnitTests.Class2.tset2\" type=\"MyFirstUnitTests.Class2\" method=\"tset2\" time=\"0.0056931\" result=\"Pass\" />" +
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
         private const string _xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<assemblies>" +
-        "<assembly name = \"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
+        "<assembly name = \"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
         "<class name=\"MyFirstUnitTests.Class1\">" +
         "<test name=\"MyFirstUnitTests.Class1.FailingTest\">" +
         "</test>" +
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         private const string _xunitResultsWithDtd = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<!DOCTYPE report PUBLIC '-//JACOCO//DTD Report 1.0//EN' 'report.dtd'>" +
         "<assemblies>" +
-        "<assembly name = \"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
+        "<assembly name = \"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
         "<class name=\"MyFirstUnitTests.Class1\">" +
         "<test name=\"MyFirstUnitTests.Class1.FailingTest\">" +
         "</test>" +
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         public void ResultsWithoutMandatoryFieldsAreSkipped()
         {
             SetupMocks();
-            string xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            var xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                                   "<assemblies>" +
                                   "<assembly>" +
                                   "<collection>" +
@@ -136,8 +136,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                                   "</assemblies>";
             WriteXUnitFile(xunitResults);
             XUnitResultReader reader = new XUnitResultReader();
-            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-            
+            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));   
             Assert.NotNull(runData);
             Assert.Equal(0, runData.Results.Length);
         }
@@ -148,9 +147,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         public void ReadResultsReturnsCorrectValues()
         {
             SetupMocks();
-            string xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            var xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
             "<assemblies>" +
-            "<assembly name=\"C:/Users/kaadhina/Source/Workspaces/p1/ClassLibrary2/ClassLibrary2/bin/Debug/ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
+            "<assembly name=\"C:/Users/somerandomusername/Source/Workspaces/p1/ClassLibrary2/ClassLibrary2/bin/Debug/ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
             "<errors />" +
             "<collection total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class1\" time=\"0.044\">" +
             "<test name=\"MyFirstUnitTests.Class1.FailingTest\" type=\"MyFirstUnitTests.Class1\" method=\"FailingTest\" time=\"1.0422319\" result=\"Fail\">" +
@@ -158,7 +157,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "<message><![CDATA[Assert.Equal() Failure" +
             "Expected: 5" +
             "Actual: 4]]></message >" +
-            "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
+            "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
             "</failure >" +
             "</test>" +
             "<test name=\"MyFirstUnitTests.Class1.PassingTest\" type=\"MyFirstUnitTests.Class1\" method=\"PassingTest\" time=\"0.0014079\" result=\"Pass\">" +
@@ -169,7 +168,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "</test>" +
             "</collection>" +
             "</assembly>" +
-            "<assembly name=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
+            "<assembly name=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
             "<errors />" +
             "<collection total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class2\" time=\"0.006\">" +
             "<test name=\"MyFirstUnitTests.Class2.tset2\" type=\"MyFirstUnitTests.Class2\" method=\"tset2\" time=\"0.0056931\" result=\"Pass\" />" +
@@ -181,46 +180,35 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "</collection>" +
             "</assembly>" +
             "</assemblies>";
-
             _xUnitResultFile = "XUnitResults.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
-
             XUnitResultReader reader = new XUnitResultReader();
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-
             Assert.Equal("XUnit Test Run debug any cpu", runData.Name);
             Assert.Equal(4, runData.Results.Length);
             Assert.Equal("debug", runData.BuildFlavor);
             Assert.Equal("any cpu", runData.BuildPlatform);
             Assert.Equal("1", runData.Build.Id);
             Assert.Equal(1, runData.Attachments.Length);
-
             Assert.Equal("Failed", runData.Results[0].Outcome);
             Assert.Equal("FailingTest", runData.Results[0].TestCaseTitle);
             Assert.Equal("MyFirstUnitTests.Class1.FailingTest", runData.Results[0].AutomatedTestName);
             Assert.Equal("Assert.Equal() FailureExpected: 5Actual: 4", runData.Results[0].ErrorMessage);
-            Assert.Equal("at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17", runData.Results[0].StackTrace);
+            Assert.Equal("at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17", runData.Results[0].StackTrace);
             Assert.Equal("Owner", runData.Results[0].RunBy.DisplayName);
             Assert.Equal("Completed", runData.Results[0].State);
             Assert.Equal("1042", runData.Results[0].DurationInMs.ToString());
             Assert.Equal("ClassLibrary2.DLL", runData.Results[0].AutomatedTestStorage);
-
-
             Assert.Equal("Passed", runData.Results[1].Outcome);
             Assert.Equal("0", runData.Results[1].Priority.ToString());
             Assert.Equal("asdf", runData.Results[1].Owner.DisplayName);
-
             Assert.Equal(null, runData.Results[0].AutomatedTestId);
             Assert.Equal(null, runData.Results[0].AutomatedTestTypeId);
-
-            
-
             DateTime startDate;
             DateTime.TryParse(runData.StartDate, out startDate);
             DateTime completeDate;
             DateTime.TryParse(runData.CompleteDate, out completeDate);
             Assert.Equal((completeDate - startDate).TotalMilliseconds, 1152);
-
             Assert.Equal("releaseUri", runData.ReleaseUri);
             Assert.Equal("releaseEnvironmentUri", runData.ReleaseEnvironmentUri);
         }
@@ -236,10 +224,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             {
                 //German is used, as in this culture decimal seperator is comma & thousand seperator is dot
                 CultureInfo.CurrentCulture = new CultureInfo("de-DE");
-
-                string xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                var xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
             "<assemblies>" +
-            "<assembly name=\"C:/Users/kaadhina/Source/Workspaces/p1/ClassLibrary2/ClassLibrary2/bin/Debug/ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
+            "<assembly name=\"C:/Users/somerandomusername/Source/Workspaces/p1/ClassLibrary2/ClassLibrary2/bin/Debug/ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
             "<errors />" +
             "<collection total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class1\" time=\"0.044\">" +
             "<test name=\"MyFirstUnitTests.Class1.FailingTest\" type=\"MyFirstUnitTests.Class1\" method=\"FailingTest\" time=\"1.0422319\" result=\"Fail\">" +
@@ -247,7 +234,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "<message><![CDATA[Assert.Equal() Failure" +
             "Expected: 5" +
             "Actual: 4]]></message >" +
-            "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
+            "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
             "</failure >" +
             "</test>" +
             "<test name=\"MyFirstUnitTests.Class1.PassingTest\" type=\"MyFirstUnitTests.Class1\" method=\"PassingTest\" time=\"0.0014079\" result=\"Pass\">" +
@@ -258,7 +245,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "</test>" +
             "</collection>" +
             "</assembly>" +
-            "<assembly name=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
+            "<assembly name=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
             "<errors />" +
             "<collection total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class2\" time=\"0.006\">" +
             "<test name=\"MyFirstUnitTests.Class2.tset2\" type=\"MyFirstUnitTests.Class2\" method=\"tset2\" time=\"0.0056931\" result=\"Pass\" />" +
@@ -270,49 +257,37 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "</collection>" +
             "</assembly>" +
             "</assemblies>";
-
                 _xUnitResultFile = "XUnitResults.xml";
                 File.WriteAllText(_xUnitResultFile, xunitResults);
-
                 XUnitResultReader reader = new XUnitResultReader();
                 TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-
                 Assert.Equal("XUnit Test Run debug any cpu", runData.Name);
                 Assert.Equal(4, runData.Results.Length);
                 Assert.Equal("debug", runData.BuildFlavor);
                 Assert.Equal("any cpu", runData.BuildPlatform);
                 Assert.Equal("1", runData.Build.Id);
                 Assert.Equal(1, runData.Attachments.Length);
-
                 Assert.Equal("Failed", runData.Results[0].Outcome);
                 Assert.Equal("FailingTest", runData.Results[0].TestCaseTitle);
                 Assert.Equal("MyFirstUnitTests.Class1.FailingTest", runData.Results[0].AutomatedTestName);
                 Assert.Equal("Assert.Equal() FailureExpected: 5Actual: 4", runData.Results[0].ErrorMessage);
-                Assert.Equal("at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17", runData.Results[0].StackTrace);
+                Assert.Equal("at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17", runData.Results[0].StackTrace);
                 Assert.Equal("Owner", runData.Results[0].RunBy.DisplayName);
                 Assert.Equal("Completed", runData.Results[0].State);
                 Assert.Equal("1042", runData.Results[0].DurationInMs.ToString());
                 Assert.Equal("ClassLibrary2.DLL", runData.Results[0].AutomatedTestStorage);
-
-
                 Assert.Equal("Passed", runData.Results[1].Outcome);
                 Assert.Equal("0", runData.Results[1].Priority.ToString());
                 Assert.Equal("asdf", runData.Results[1].Owner.DisplayName);
-
                 Assert.Equal(null, runData.Results[0].AutomatedTestId);
                 Assert.Equal(null, runData.Results[0].AutomatedTestTypeId);
-
-
-
                 DateTime startDate;
                 DateTime.TryParse(runData.StartDate, out startDate);
                 DateTime completeDate;
                 DateTime.TryParse(runData.CompleteDate, out completeDate);
                 Assert.Equal((completeDate - startDate).TotalMilliseconds, 1152);
-
                 Assert.Equal("releaseUri", runData.ReleaseUri);
                 Assert.Equal("releaseEnvironmentUri", runData.ReleaseEnvironmentUri);
-
             }
             finally
             {
@@ -328,13 +303,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             SetupMocks();
             string xunitResults = c_parallelXunitResults;
             XUnitResultReader reader = new XUnitResultReader();
-
             _xUnitResultFile = "XUnitResults.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-
             Assert.Equal(40, (int)runData.Results[0].DurationInMs);
-
             DateTime startDate, completeDate;
             DateTime.TryParse(runData.StartDate, out startDate);
             Assert.Equal("2016-06-08T07:12:09.0000000", startDate.ToString("o"));
@@ -376,12 +348,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             //no run-time tag present
             string xunitResults = c_parallelXunitResults;
             XUnitResultReader reader = new XUnitResultReader();
-
             xunitResults = xunitResults.Replace("run-time", "timer").Replace("run-date", "dater");
             _xUnitResultFile = "BadXUnitResults2.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-
             DateTime startDate, completeDate;
             Assert.Equal(40, (int)runData.Results[0].DurationInMs);
             DateTime.TryParse(runData.StartDate, out startDate);
@@ -399,12 +369,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             //no assembly time tag present
             string xunitResults = c_parallelXunitResults;
             XUnitResultReader reader = new XUnitResultReader();
-
             xunitResults = xunitResults.Replace("run-time", "timer").Replace("run-date", "dater").Replace("time=\"5.417\"", "t=\"5.417\"");
             _xUnitResultFile = "BadXUnitResults3.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-
             DateTime startDate, completeDate;
             Assert.Equal(40, (int)runData.Results[0].DurationInMs);
             DateTime.TryParse(runData.StartDate, out startDate);
@@ -420,7 +388,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             var runData = ReadResults();
-
             Assert.Equal("My Run Title", runData.Name);
         }
 
@@ -430,22 +397,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         public void ReadResultsDoesNotFailForV1()
         {
             SetupMocks();
-            string xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            var xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
             "<assemblies>" +
-            "<assembly name = \"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
+            "<assembly name = \"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
             "<class name=\"MyFirstUnitTests.Class1\">" +
             "<test name=\"MyFirstUnitTests.Class1.FailingTest\">" +
             "</test>" +
             "</class>" +
             "</assembly>" +
             "</assemblies>";
-
             _xUnitResultFile = "BadXUnitResults.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
-
             XUnitResultReader reader = new XUnitResultReader();
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext(null, null, null, 0, null, null, null));
-
             Assert.Equal(0, runData.Results.Length);
         }
 
@@ -455,15 +419,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         public void ReadResultsDoesNotFailForBadXml()
         {
             SetupMocks();
-            string xunitResults = "<random>" +
+            var xunitResults = "<random>" +
             "</random>";
-
             _xUnitResultFile = "BadXUnitResults.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
-
             XUnitResultReader reader = new XUnitResultReader();
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext(null, null, null, 0, null, null, null));
-
             Assert.Equal(0, runData.Results.Length);
         }
 
@@ -494,7 +455,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             var runData = ReadResults();
-
             Assert.Equal(1, runData.Attachments.Length);
         }
 
@@ -505,7 +465,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         {
             SetupMocks();
             var runData = ReadResults(false);
-
             Assert.Equal(0, runData.Attachments.Length);
         }
 
@@ -600,7 +559,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
         private TestRunData GetTestRunData()
         {
-            string xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            var xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                                   "<assemblies>" +
                                   "<assembly>" +
                                   "<collection>" +
@@ -612,7 +571,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
             _xUnitResultFile = "BareMinimumXUnitResults.xml";
             File.WriteAllText(_xUnitResultFile, xunitResults);
-
             _xUnitReader = new XUnitResultReader();
             TestRunData runData = _xUnitReader.ReadResults(_ec.Object, _xUnitResultFile,
                 new TestRunContext(null, null, null, 0, null, null, null));
@@ -628,7 +586,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         private TestRunData ReadResults(bool attachRunLevelAttachments = true, bool fullResults = false)
         {
             WriteXUnitFile(fullResults ? _xunitResultsFull : _xunitResults);
-
             return ReadResultsInternal(attachRunLevelAttachments);
         }
 

--- a/src/Test/L0/Worker/TestResults/XUnitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/XUnitResultReaderTests.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Globalization;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
@@ -50,6 +52,50 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         "</assembly>" +
         "</assemblies>";
 
+        private const string c_parallelXunitResults = "<?xml version =\"1.0\" encoding=\"utf-8\"?>" +
+           "<assemblies>" +
+           "<assembly name=\"c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.34014 [collection-per-class, parallel (4 threads)]\" test-framework=\"xUnit.net 2.1.0.3179\" run-date=\"2016-06-08\" run-time=\"07:12:09\" config-file=\"c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\packages\\xunit.runner.console.2.1.0\\tools\\xunit.console.exe.Config\" total=\"5\" passed=\"3\" failed=\"2\" skipped=\"0\" time=\"5.433\" errors=\"0\">" +
+           "<errors />" +
+           "<collection total=\"5\" passed=\"3\" failed=\"2\" skipped=\"0\" name=\"Test collection for ClassLibrary2.Class1\" time=\"5.068\">" +
+           "<test name=\"ClassLibrary2.Class1.MyFirstTheory(value: 5)\" type=\"ClassLibrary2.Class1\" method=\"MyFirstTheory\" time=\"0.0398995\" result=\"Pass\" />" +
+           "<test name=\"ClassLibrary2.Class1.MyFirstTheory(value: 3)\" type=\"ClassLibrary2.Class1\" method=\"MyFirstTheory\" time=\"0.0000573\" result=\"Pass\" />" +
+           "<test name=\"ClassLibrary2.Class1.MyFirstTheory(value: 6)\" type=\"ClassLibrary2.Class1\" method=\"MyFirstTheory\" time=\"0.0047208\" result=\"Fail\">" +
+           "<failure exception-type=\"Xunit.Sdk.TrueException\">" +
+           "<message><![CDATA[Assert.True() Failure\r\nExpected: True\r\nActual:   False]]></message>" +
+           "<stack-trace><![CDATA[   at ClassLibrary2.Class1.MyFirstTheory(Int32 value) in c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 37]]></stack-trace>" +
+           "</failure>" +
+           "</test>" +
+           "<test name=\"ClassLibrary2.Class1.FailingTest\" type=\"ClassLibrary2.Class1\" method=\"FailingTest\" time=\"0.0106463\" result=\"Fail\">" +
+           "<failure exception-type=\"Xunit.Sdk.EqualException\">" +
+           "<message><![CDATA[Assert.Equal() Failure\r\nExpected: 5\r\nActual:   4]]></message>" +
+           "<stack-trace><![CDATA[   at ClassLibrary2.Class1.FailingTest() in c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 23]]></stack-trace>" +
+           "</failure>" +
+           "</test>" +
+           "<test name=\"ClassLibrary2.Class1.PassingTest\" type=\"ClassLibrary2.Class1\" method=\"PassingTest\" time=\"5.0128822\" result=\"Pass\" />" +
+            "</collection>" +
+           "</assembly>" +
+           "<assembly name=\"c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.34014 [collection-per-class, parallel (4 threads)]\" test-framework=\"xUnit.net 2.1.0.3179\" run-date=\"2016-06-08\" run-time=\"07:12:09\" config-file=\"c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\packages\\xunit.runner.console.2.1.0\\tools\\xunit.console.exe.Config\" total=\"5\" passed=\"3\" failed=\"2\" skipped=\"0\" time=\"5.417\" errors=\"0\">" +
+           "<errors />" +
+           "<collection total=\"5\" passed=\"3\" failed=\"2\" skipped=\"0\" name=\"Test collection for ClassLibrary1.Classvs\" time=\"5.067\">" +
+           "<test name=\"ClassLibrary1.Classvs.PassingTest1\" type=\"ClassLibrary1.Classvs\" method=\"PassingTest1\" time=\"5.0549175\" result=\"Pass\" />" +
+           "<test name=\"ClassLibrary1.Classvs.FailingTest1\" type=\"ClassLibrary1.Classvs\" method=\"FailingTest1\" time=\"0.0102656\" result=\"Fail\">" +
+           "<failure exception-type=\"Xunit.Sdk.EqualException\">" +
+           "<message><![CDATA[Assert.Equal() Failure\r\nExpected: 5\r\nActual:   4]]></message>" +
+           "<stack-trace><![CDATA[   at ClassLibrary1.Classvs.FailingTest1() in c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\ClassLibrary1\\Classvs.cs:line 23]]></stack-trace>" +
+           "</failure>" +
+           "</test>" +
+           "<test name=\"ClassLibrary1.Classvs.MySecondTheory(value: 5)\" type=\"ClassLibrary1.Classvs\" method=\"MySecondTheory\" time=\"0.0010502\" result=\"Pass\" />" +
+           "<test name=\"ClassLibrary1.Classvs.MySecondTheory(value: 3)\" type=\"ClassLibrary1.Classvs\" method=\"MySecondTheory\" time=\"0.0000131\" result=\"Pass\" />" +
+           "<test name=\"ClassLibrary1.Classvs.MySecondTheory(value: 6)\" type=\"ClassLibrary1.Classvs\" method=\"MySecondTheory\" time=\"0.0008241\" result=\"Fail\">" +
+           "<failure exception-type=\"Xunit.Sdk.TrueException\" > " +
+           "<message><![CDATA[Assert.True() Failure\r\nExpected: True\r\nActual:   False]]></message>" +
+           "<stack-trace><![CDATA[   at ClassLibrary1.Classvs.MySecondTheory(Int32 value) in c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\ClassLibrary1\\Classvs.cs:line 37]]></stack-trace>" +
+           "</failure>" +
+           "</test>" +
+           "</collection>" +
+           "</assembly>" +
+           "</assemblies>";
+
         private const string _xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<assemblies>" +
         "<assembly name = \"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\">" +
@@ -91,7 +137,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             WriteXUnitFile(xunitResults);
             XUnitResultReader reader = new XUnitResultReader();
             TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
-
+            
             Assert.NotNull(runData);
             Assert.Equal(0, runData.Results.Length);
         }
@@ -167,21 +213,204 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             Assert.Equal(null, runData.Results[0].AutomatedTestId);
             Assert.Equal(null, runData.Results[0].AutomatedTestTypeId);
 
-            double runDuration = 0;
-            foreach (TestCaseResultData result in runData.Results)
-            {
-                runDuration += result.DurationInMs;
-            }
+            
 
             DateTime startDate;
             DateTime.TryParse(runData.StartDate, out startDate);
             DateTime completeDate;
             DateTime.TryParse(runData.CompleteDate, out completeDate);
-            TimeSpan duration = completeDate - startDate;
-            Assert.Equal((completeDate - startDate).TotalMilliseconds, runDuration);
+            Assert.Equal((completeDate - startDate).TotalMilliseconds, 1152);
 
             Assert.Equal("releaseUri", runData.ReleaseUri);
             Assert.Equal("releaseEnvironmentUri", runData.ReleaseEnvironmentUri);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void ReadsResultsReturnsCorrectValuesInDifferentCulture()
+        {
+            SetupMocks();
+            CultureInfo current = CultureInfo.CurrentCulture;
+            try
+            {
+                //German is used, as in this culture decimal seperator is comma & thousand seperator is dot
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+                string xunitResults = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            "<assemblies>" +
+            "<assembly name=\"C:/Users/kaadhina/Source/Workspaces/p1/ClassLibrary2/ClassLibrary2/bin/Debug/ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:15\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" time=\"0.233\" errors=\"0\">" +
+            "<errors />" +
+            "<collection total=\"2\" passed=\"1\" failed=\"1\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class1\" time=\"0.044\">" +
+            "<test name=\"MyFirstUnitTests.Class1.FailingTest\" type=\"MyFirstUnitTests.Class1\" method=\"FailingTest\" time=\"1.0422319\" result=\"Fail\">" +
+            "<failure exception-type=\"Xunit.Sdk.EqualException\" >" +
+            "<message><![CDATA[Assert.Equal() Failure" +
+            "Expected: 5" +
+            "Actual: 4]]></message >" +
+            "<stack-trace><![CDATA[at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17]]></stack-trace>" +
+            "</failure >" +
+            "</test>" +
+            "<test name=\"MyFirstUnitTests.Class1.PassingTest\" type=\"MyFirstUnitTests.Class1\" method=\"PassingTest\" time=\"0.0014079\" result=\"Pass\">" +
+            "<traits>" +
+            "<trait name=\"priority\" value=\"0\" />" +
+            "<trait name=\"owner\" value=\"asdf\" />" +
+            "</traits>" +
+            "</test>" +
+            "</collection>" +
+            "</assembly>" +
+            "<assembly name=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary1\\bin\\Debug\\ClassLibrary1.DLL\" environment=\"64-bit .NET 4.0.30319.42000 [collection-per-class, parallel]\" test-framework=\"xUnit.net 2.0.0.2929\" run-date=\"2015-08-18\" run-time=\"06:17:16\" config-file=\"C:\\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\packages\\xunit.runner.console.2.0.0\\tools\\xunit.console.exe.Config\" total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" time=\"0.152\" errors=\"0\">" +
+            "<errors />" +
+            "<collection total=\"2\" passed=\"2\" failed=\"0\" skipped=\"0\" name=\"Test collection for MyFirstUnitTests.Class2\" time=\"0.006\">" +
+            "<test name=\"MyFirstUnitTests.Class2.tset2\" type=\"MyFirstUnitTests.Class2\" method=\"tset2\" time=\"0.0056931\" result=\"Pass\" />" +
+            "<test name=\"MyFirstUnitTests.Class2.test1\" type=\"MyFirstUnitTests.Class2\" method=\"test1\" time=\"0.0001093\" result=\"Pass\">" +
+            "<traits>" +
+            "<trait name=\"priority\" value=\"0\" />" +
+            "</traits>" +
+            "</test>" +
+            "</collection>" +
+            "</assembly>" +
+            "</assemblies>";
+
+                _xUnitResultFile = "XUnitResults.xml";
+                File.WriteAllText(_xUnitResultFile, xunitResults);
+
+                XUnitResultReader reader = new XUnitResultReader();
+                TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+                Assert.Equal("XUnit Test Run debug any cpu", runData.Name);
+                Assert.Equal(4, runData.Results.Length);
+                Assert.Equal("debug", runData.BuildFlavor);
+                Assert.Equal("any cpu", runData.BuildPlatform);
+                Assert.Equal("1", runData.Build.Id);
+                Assert.Equal(1, runData.Attachments.Length);
+
+                Assert.Equal("Failed", runData.Results[0].Outcome);
+                Assert.Equal("FailingTest", runData.Results[0].TestCaseTitle);
+                Assert.Equal("MyFirstUnitTests.Class1.FailingTest", runData.Results[0].AutomatedTestName);
+                Assert.Equal("Assert.Equal() FailureExpected: 5Actual: 4", runData.Results[0].ErrorMessage);
+                Assert.Equal("at MyFirstUnitTests.Class1.FailingTest() in C: \\Users\\kaadhina\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\Class1.cs:line 17", runData.Results[0].StackTrace);
+                Assert.Equal("Owner", runData.Results[0].RunBy.DisplayName);
+                Assert.Equal("Completed", runData.Results[0].State);
+                Assert.Equal("1042", runData.Results[0].DurationInMs.ToString());
+                Assert.Equal("ClassLibrary2.DLL", runData.Results[0].AutomatedTestStorage);
+
+
+                Assert.Equal("Passed", runData.Results[1].Outcome);
+                Assert.Equal("0", runData.Results[1].Priority.ToString());
+                Assert.Equal("asdf", runData.Results[1].Owner.DisplayName);
+
+                Assert.Equal(null, runData.Results[0].AutomatedTestId);
+                Assert.Equal(null, runData.Results[0].AutomatedTestTypeId);
+
+
+
+                DateTime startDate;
+                DateTime.TryParse(runData.StartDate, out startDate);
+                DateTime completeDate;
+                DateTime.TryParse(runData.CompleteDate, out completeDate);
+                Assert.Equal((completeDate - startDate).TotalMilliseconds, 1152);
+
+                Assert.Equal("releaseUri", runData.ReleaseUri);
+                Assert.Equal("releaseEnvironmentUri", runData.ReleaseEnvironmentUri);
+
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = current;
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyReadResultsReturnsDurationAsDiffBetweenMinStartAndMaxCompletedTime()
+        {
+            SetupMocks();
+            string xunitResults = c_parallelXunitResults;
+            XUnitResultReader reader = new XUnitResultReader();
+
+            _xUnitResultFile = "XUnitResults.xml";
+            File.WriteAllText(_xUnitResultFile, xunitResults);
+            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+            Assert.Equal(40, (int)runData.Results[0].DurationInMs);
+
+            DateTime startDate, completeDate;
+            DateTime.TryParse(runData.StartDate, out startDate);
+            Assert.Equal("2016-06-08T07:12:09.0000000", startDate.ToString("o"));
+            DateTime.TryParse(runData.CompleteDate, out completeDate);
+            Assert.Equal("2016-06-08T07:12:14.4330000", completeDate.ToString("o"));
+            Assert.Equal((completeDate - startDate).TotalMilliseconds, 5433);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyReadResultsReturnsDurationAsSumOfAssemblyTimeWhenRunDateNotParseable()
+        {
+            SetupMocks();
+            //improper date format
+            string xunitResults = c_parallelXunitResults;
+            XUnitResultReader reader = new XUnitResultReader();
+
+            xunitResults = xunitResults.Replace(" run-date=\"2016-06-08\" ", " run-date=\"201-06--08\" ");
+            _xUnitResultFile = "BadXUnitResults1.xml";
+            File.WriteAllText(_xUnitResultFile, xunitResults);
+            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+            DateTime startDate, completeDate;
+            Assert.Equal(40, (int)runData.Results[0].DurationInMs);
+            DateTime.TryParse(runData.StartDate, out startDate);
+            Assert.NotEqual("2016-06-08T07:12:09.0000000", startDate.ToString("o"));
+            DateTime.TryParse(runData.CompleteDate, out completeDate);
+            Assert.Equal((completeDate - startDate).TotalMilliseconds, 10850);
+
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyReadResultsReturnsDurationAsSumOfAssemblyTimeWhenRunDateNotAvailable()
+        {
+            SetupMocks();
+            //no run-time tag present
+            string xunitResults = c_parallelXunitResults;
+            XUnitResultReader reader = new XUnitResultReader();
+
+            xunitResults = xunitResults.Replace("run-time", "timer").Replace("run-date", "dater");
+            _xUnitResultFile = "BadXUnitResults2.xml";
+            File.WriteAllText(_xUnitResultFile, xunitResults);
+            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+            DateTime startDate, completeDate;
+            Assert.Equal(40, (int)runData.Results[0].DurationInMs);
+            DateTime.TryParse(runData.StartDate, out startDate);
+            Assert.NotEqual("2016-06-08T07:12:09.0000000", startDate.ToString("o"));
+            DateTime.TryParse(runData.CompleteDate, out completeDate);
+            Assert.Equal((completeDate - startDate).TotalMilliseconds, 10850);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyReadResultsReturnsDurationAsSumOfTestCaseTimeWhenAssemblyTimeTagsNotAvailable()
+        {
+            SetupMocks();
+            //no assembly time tag present
+            string xunitResults = c_parallelXunitResults;
+            XUnitResultReader reader = new XUnitResultReader();
+
+            xunitResults = xunitResults.Replace("run-time", "timer").Replace("run-date", "dater").Replace("time=\"5.417\"", "t=\"5.417\"");
+            _xUnitResultFile = "BadXUnitResults3.xml";
+            File.WriteAllText(_xUnitResultFile, xunitResults);
+            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+            DateTime startDate, completeDate;
+            Assert.Equal(40, (int)runData.Results[0].DurationInMs);
+            DateTime.TryParse(runData.StartDate, out startDate);
+            Assert.NotEqual("2016-06-08T07:12:09.0000000", startDate.ToString("o"));
+            DateTime.TryParse(runData.CompleteDate, out completeDate);
+            Assert.Equal((completeDate - startDate).TotalMilliseconds, 10135);
         }
 
         [Fact]
@@ -320,23 +549,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "PublishTestResults")]
-        public void VerifyStartDateIsEmptyWhenNoRunTimeIsAvailable()
+        public void VerifyStartDateIsNotEmpty()
         {
             SetupMocks();
             var resultsWithNoTime = _xunitResultsFull.Replace("run-time", "timer").Replace("run-date", "dater");
             var testRunData = ReadResults(resultsWithNoTime);
-            Assert.Equal(string.Empty, testRunData.StartDate);
+            Assert.NotEqual(string.Empty, testRunData.StartDate);
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "PublishTestResults")]
-        public void VerifyEndDateIsEmptyWhenNoRunTimeIsAvailable()
+        public void VerifyEndDateIsNotEmpty()
         {
             SetupMocks();
             var resultsWithNoTime = _xunitResultsFull.Replace("run-time", "timer").Replace("run-date", "dater");
             var testRunData = ReadResults(resultsWithNoTime);
-            Assert.Equal(string.Empty, testRunData.CompleteDate);
+            Assert.NotEqual(string.Empty, testRunData.CompleteDate);
         }
 
         [Fact]


### PR DESCRIPTION
Fix for #620331 and #636011

**Changes for duration calculation of xunit & junit test results, moving to clock time calculation to correctly determine run duration especially for parallel test execution**

Run duration is calculated as per following order:

1. Determine start time and end time for each assembly/testsuite and then duration = diff of minimum start time and maximum completed time.
2. If 1. is not available (even for single testsuite/assembly) , then calculate duration based on summation of time taken by each assembly/test suite.
3. If 2. cannot be done (even for single testsuite/assembly), then calculate duration based on summation of time taken by each test-case.

_Note: Till nunit 2.6, parallelization case cannot be handled as nunit doesn't publish start time for each test suite, hence clock time cannot be obtained. Nunit 3.0 onward the results file format has changed, we need to modify or add a new reader accordingly, which is to be tracked separately and is not taken care as of now._

**Changed readers to read xml double, date, time values in invariant culture**

**Added unit tests**

To validate, I ran created a task to publish test results from an xml which was generated when test assemblies ran in parallel (xunit). In case of Junit, I duplicated the xml nodes and adjusted the time stamps to verify. I manually tested publish test result task end to end.