### PR TITLE
Fix typo in /etc/bashrc

### DIFF
--- a/docs/start/envredhat.md
+++ b/docs/start/envredhat.md
@@ -33,7 +33,7 @@ $ make prefix=/usr/local/git all
 $ make prefix=/usr/local/git install
 ```
 
-In /etc/bash.rs
+In /etc/bashrc
 ```bash
 export PATH=$PATH:/usr/local/git/bin
 ```


### PR DESCRIPTION
I'm pretty sure `/etc/bashrc` was intended, as that's what the [linked article](http://tecadmin.net/install-git-2-x-on-centos-rhel-and-fedora/#) has.