### PR TITLE
Fix typo in /etc/bashrc

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -53,7 +53,7 @@ $ make prefix=/usr/local/git all
 $ make prefix=/usr/local/git install
 ```
 
-In /etc/bash.rs
+In /etc/bashrc
 ```bash
 export PATH=$PATH:/usr/local/git/bin
 ```


### PR DESCRIPTION
I just noticed the same typo as in #497 exists here, too.