### PR TITLE
Modify Ant build files which lies under current build file folder only

### DIFF
--- a/src/Agent.Worker/CodeCoverage/CodeCoverageEnablerForCoberturaAnt.cs
+++ b/src/Agent.Worker/CodeCoverage/CodeCoverageEnablerForCoberturaAnt.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage
 
             ccInputs.VerifyInputsForCoberturaAnt(context);
 
-            string sourcesDirectory = context.Variables.Build_SourcesDirectory;
+            var sourcesDirectory = Path.GetDirectoryName(ccInputs.BuildFile);
             if (string.IsNullOrWhiteSpace(sourcesDirectory))
             {
                 throw new InvalidOperationException(StringUtil.Loc("InvalidSourceDirectory"));

--- a/src/Agent.Worker/CodeCoverage/CodeCoverageEnablerForJacocoAnt.cs
+++ b/src/Agent.Worker/CodeCoverage/CodeCoverageEnablerForJacocoAnt.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage
 
             ccInputs.VerifyInputsForJacocoAnt(context);
 
-            string sourcesDirectory = context.Variables.Build_SourcesDirectory;
+            var sourcesDirectory = Path.GetDirectoryName(ccInputs.BuildFile);
             if (string.IsNullOrWhiteSpace(sourcesDirectory))
             {
                 throw new InvalidOperationException(StringUtil.Loc("InvalidSourceDirectory"));


### PR DESCRIPTION
* Currently if ant task is enabled with code coverage option, it tries to look out for all valid build xml files in build sources directory instead of ant build directory. This issue is fixed to look for build files under build path only.