### PR TITLE
Updated the documentation for pre reqs on windows machine

### DIFF
--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -1,10 +1,6 @@
 # ![win](../res/win_med.png) Windows System Pre-requisites
 
-## Windows 8 and Beyond (64-bit)
-
-No known system pre-requisistes are known at this time.
-
-## Windows 7 and Windows Server 2012 R2 (64-bit)
+## Windows 7 and above including Windows Server 2012 R2 (64-bit)
 
 [Updated C runtime is needed](https://support.microsoft.com/en-us/kb/2999226)
 

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -1,6 +1,10 @@
 # ![win](../res/win_med.png) Windows System Pre-requisites
 
-## Windows 7 and above including Windows Server 2012 R2 (64-bit)
+## Windows 10 and Beyond (64-bit)
+
+No known system pre-requisistes are known at this time.
+
+## Windows 7 to Windows 8.1 and Windows Server 2012 R2 (64-bit)
 
 [Updated C runtime is needed](https://support.microsoft.com/en-us/kb/2999226)
 


### PR DESCRIPTION
Windows 8.1 and beyond also requires Universal C runtime for agent to
work. Tested on a clean windows 8.1. After installing universal C runtime things started to work