### PR TITLE
Adjust detection logic for Xamarin.Android

### DIFF
--- a/src/Agent.Listener/Capabilities/NixCapabilitiesProvider.cs
+++ b/src/Agent.Listener/Capabilities/NixCapabilitiesProvider.cs
@@ -67,8 +67,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Capabilities
                 filePaths: new string[] { "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool" });
             builder.Check(
                 name: "Xamarin.Android",
-                fileName: "mandroid",
-                filePaths: new string[] { "/Library/Frameworks/Xamarin.Android.framework/Commands/mandroid" });
+                fileName: "generator",
+                filePaths: new string[] { "/Library/Frameworks/Xamarin.Android.framework/Commands/generator" });
             await builder.CheckToolOutputAsync(
                 name: "xcode",
                 fileName: "xcode-select",


### PR DESCRIPTION
The `mandroid` binary has been deprecated and is missing from installs of Xamarin.Android 6.2 (Cycle 8) and higher.

Look for the `generator` binary instead which is located in the same folder and has been present for several years.