### PR TITLE
Adding task.order variable

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         List<ServiceEndpoint> Endpoints { get; }
         Variables Variables { get; }
         List<IAsyncCommandContext> AsyncCommands { get; }
+        int? Order { get;  }
 
         // Initialize
         void InitializeJob(JobRequestMessage message, CancellationToken token);
@@ -109,6 +110,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             set
             {
                 _record.ResultCode = value;
+            }
+        }
+
+        public int? Order
+        {
+            get
+            {
+                return _record.Order;
             }
         }
 

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             // Set the task display name variable.
             ExecutionContext.Variables.Set(Constants.Variables.Task.DisplayName, DisplayName);
+            ExecutionContext.Variables.Set(Constants.Variables.Task.Order, ExecutionContext.Order.ToString());
 
             // Load the task definition and choose the handler.
             // TODO: Add a try catch here to give a better error message.

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -298,6 +298,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             public static class Task
             {
                 public static readonly string DisplayName = "task.displayname";
+                public static readonly string Order = "task.order";
             }
         }
     }


### PR DESCRIPTION
PR to add a variable task.Order. This exposes timeline record order. This variable can be used by tasks to gets its order in execution.