### PR TITLE
Bug fixes on the RM file share artifact

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/CustomArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/CustomArtifact.cs
@@ -130,9 +130,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             else
             {
                 string resourceType = streamType;
-                var errorMessage = StringUtil.Loc("RMStreamTypeNotSupported", resourceType);
-                executionContext.Output(errorMessage);
-                throw new NotSupportedException(errorMessage);
+                var warningMessage = StringUtil.Loc("RMStreamTypeNotSupported", resourceType);
+                executionContext.Warning(warningMessage);
             }
         }
 

--- a/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
@@ -35,10 +35,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             {
                 foreach (var filePath in filePaths)
                 {
-                    var filePathRelativeToDrop = filePath.Replace(dropLocation, string.Empty).Trim(trimChars);
-                    using (var fileReader = fileSystemManager.GetFileReader(filePath))
+                    var fullPath = Path.GetFullPath(filePath);
+                    if (File.Exists(fullPath))
                     {
-                        await fileSystemManager.WriteStreamToFile(fileReader.BaseStream, Path.Combine(localFolderPath, filePathRelativeToDrop));
+                        var filePathRelativeToDrop = filePath.Replace(dropLocation, string.Empty).Trim(trimChars);
+                        using (var fileReader = fileSystemManager.GetFileReader(filePath))
+                        {
+                            await fileSystemManager.WriteStreamToFile(fileReader.BaseStream, Path.Combine(localFolderPath, filePathRelativeToDrop));
+                        }
+                    }
+                    else
+                    {
+                        executionContext.Warning(StringUtil.Loc("FileNotFound", fullPath));
                     }
                 }
             }

--- a/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
@@ -35,11 +35,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             {
                 foreach (var filePath in filePaths)
                 {
-                    var fullPath = Path.GetFullPath(filePath);
+                    string fullPath = Path.GetFullPath(filePath);
                     if (File.Exists(fullPath))
                     {
-                        var filePathRelativeToDrop = filePath.Replace(dropLocation, string.Empty).Trim(trimChars);
-                        using (var fileReader = fileSystemManager.GetFileReader(filePath))
+                        string filePathRelativeToDrop = filePath.Replace(dropLocation, string.Empty).Trim(trimChars);
+                        using (StreamReader fileReader = fileSystemManager.GetFileReader(filePath))
                         {
                             await fileSystemManager.WriteStreamToFile(fileReader.BaseStream, Path.Combine(localFolderPath, filePathRelativeToDrop));
                         }

--- a/src/Agent.Worker/Release/ReleaseFileSystemManager.cs
+++ b/src/Agent.Worker/Release/ReleaseFileSystemManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
             string path = Path.Combine(ValidatePath(filePath));
             if (!File.Exists(path))
             {
-                throw new FileNotFoundException("fileName");
+                throw new FileNotFoundException(StringUtil.Loc("FileNotFound", string.Empty), path);
             }
 
             return new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, StreamBufferSize, true));

--- a/src/Agent.Worker/Release/ReleaseFileSystemManager.cs
+++ b/src/Agent.Worker/Release/ReleaseFileSystemManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
             string path = Path.Combine(ValidatePath(filePath));
             if (!File.Exists(path))
             {
-                throw new FileNotFoundException(StringUtil.Loc("FileNotFound", string.Empty), path);
+                throw new FileNotFoundException(StringUtil.Loc("FileNotFound", path));
             }
 
             return new StreamReader(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, StreamBufferSize, true));


### PR DESCRIPTION
681683: Stopped throwing exception from custom artifact type and rather logged it as a warning.
681685: Did a precheck to ensure that the file exists and logged appropriate warning message.