### PR TITLE
Fix: Bug 730629: Download artifacts failed due to Git checkout failure in …

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/GitHubArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/GitHubArtifact.cs
@@ -53,7 +53,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             gitHubEndpoint.Data.Add(Constants.EndpointData.SourceBranch, gitHubDetails.Branch);
             gitHubEndpoint.Data.Add(Constants.EndpointData.SourceVersion, artifactDefinition.Version);
 
-            await sourceProvider.GetSourceAsync(executionContext, gitHubEndpoint, executionContext.CancellationToken);
+            try
+            {
+                await sourceProvider.GetSourceAsync(executionContext, gitHubEndpoint, executionContext.CancellationToken);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new ArtifactDownloadException(StringUtil.Loc("RMDownloadArtifactUnexpectedError"), ex);
+            }
         }
 
         public IArtifactDetails GetArtifactDetails(

--- a/src/Agent.Worker/Release/Artifacts/TfsGitArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/TfsGitArtifact.cs
@@ -44,7 +44,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             tfsGitEndpoint.Data.Add(Constants.EndpointData.SourceBranch, gitArtifactDetails.Branch);
             tfsGitEndpoint.Data.Add(Constants.EndpointData.SourceVersion, artifactDefinition.Version);
 
-            await sourceProvider.GetSourceAsync(executionContext, tfsGitEndpoint, executionContext.CancellationToken);
+            try
+            {
+                await sourceProvider.GetSourceAsync(executionContext, tfsGitEndpoint, executionContext.CancellationToken);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new ArtifactDownloadException(StringUtil.Loc("RMDownloadArtifactUnexpectedError"), ex);
+            }
         }
 
         public IArtifactDetails GetArtifactDetails(IExecutionContext context, AgentArtifactDefinition agentArtifactDefinition)

--- a/src/Test/L0/Worker/Release/GitHubArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/GitHubArtifactL0.cs
@@ -91,6 +91,37 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void GitHubArtifactShouldMapSourceProviderInvalidOperationExceptionToArtifactDownloadException()
+        {
+            using (TestHostContext tc = Setup())
+            {
+                var gitHubArtifact = new GitHubArtifact();
+                gitHubArtifact.Initialize(tc);
+
+                _ec.Setup(x => x.Endpoints)
+                    .Returns(
+                        new List<ServiceEndpoint>
+                        {
+                            new ServiceEndpoint
+                            {
+                                Name = _githubConnectionName,
+                                Url = new Uri("http://contoso.visualstudio.com"),
+                                Authorization = new EndpointAuthorization()
+                            }
+                        });
+
+                _sourceProvider.Setup(
+                    x => x.GetSourceAsync(It.IsAny<IExecutionContext>(), It.IsAny<ServiceEndpoint>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => { throw new InvalidOperationException("InvalidOperationException"); });
+
+                Assert.Throws<ArtifactDownloadException>(
+                    () => gitHubArtifact.DownloadAsync(_ec.Object, _artifactDefinition, "localFolderPath").SyncResult());
+            }
+        }
+
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);

--- a/src/Test/L0/Worker/Release/TfsGitArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/TfsGitArtifactL0.cs
@@ -91,6 +91,40 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void TfsGitArtifactShouldMapSourceProviderInvalidOperationExceptionToArtifactDownloadException()
+        {
+            using (TestHostContext tc = Setup())
+            {
+                var tfsGitArtifact = new TfsGitArtifact();
+                tfsGitArtifact.Initialize(tc);
+
+                _ec.Setup(x => x.Endpoints)
+                    .Returns(
+                        new List<ServiceEndpoint>
+                        {
+                            new ServiceEndpoint
+                            {
+                                Name = _expectedRepositoryId,
+                                Url = new Uri(_expectedUrl),
+                                Authorization = new EndpointAuthorization
+                                {
+                                    Scheme = EndpointAuthorizationSchemes.OAuth
+                                }
+                            }
+                        });
+
+                _sourceProvider.Setup(
+                    x => x.GetSourceAsync(It.IsAny<IExecutionContext>(), It.IsAny<ServiceEndpoint>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => { throw new InvalidOperationException("InvalidOperationException"); });
+
+                Assert.Throws<ArtifactDownloadException>(
+                    () => tfsGitArtifact.DownloadAsync(_ec.Object, _artifactDefinition, "localFolderPath").SyncResult());
+            }
+        }
+
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);


### PR DESCRIPTION
…SBR SU, reported through CustomerIntelligence

TFS Git check out fails for incorrect commit id