### PR TITLE
Fix config.sh to keep arguments with spaces intact

### DIFF
--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -11,9 +11,9 @@ fi
 source ./env.sh
 
 if [[ "$1" == "remove" ]]; then
-    ./bin/Agent.Listener $*
+    ./bin/Agent.Listener "$@"
 else
     # user_name=`id -nu $user_id`
 
-    ./bin/Agent.Listener configure $*
+    ./bin/Agent.Listener configure "$@"
 fi


### PR DESCRIPTION
Because $* in a Bash script corresponds to a string of the command line arguments joined together with spaces, the current implementation of "config.sh" does not keep arguments with spaces in them intact, instead separating them into separate arguments. This can be corrected by using "$@" instead, which keeps all of the original arguments intact, regardless of any spaces they contain. 

For example, if you run a command with a space in one of the option values, such as for the pool:
$ ./config.sh --unattended --acceptteeeula --url https://myaccount.visualstudio.com --auth PAT --token <token> --pool "Default Pool" --agent myagent

It will split the "Default Pool" argument into two when passing it on to "bin/Agent.Listener", which means that the value "Default" is recognized for the pool setting, and the extra word "Pool" is then treated as its own, unrecognized argument, instead of keeping "Default Pool" as a single argument.