### PR TITLE
Also check for Visual Studio for Mac for Xamarin.iOS

### DIFF
--- a/src/Agent.Listener/Capabilities/NixCapabilitiesProvider.cs
+++ b/src/Agent.Listener/Capabilities/NixCapabilitiesProvider.cs
@@ -63,7 +63,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Capabilities
             builder.Check(
                 name: "Xamarin.iOS",
                 fileName: "mdtool",
-                filePaths: new string[] { "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool" });
+                filePaths: new string[] { 
+                    "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool",
+                    "/Applications/Visual Studio.app/Contents/MacOS/vstool"
+                });
             builder.Check(
                 name: "Xamarin.Android",
                 fileName: "generator",


### PR DESCRIPTION
Xamarin Studio rebranded and we should check for both Visual Studio on Mac as well as Xamarin Studio for Xamarin.iOS capability.