### PR TITLE
Change runtime sku requirement to .NET 4.5

### DIFF
--- a/src/Agent.Service/Windows/App.config
+++ b/src/Agent.Service/Windows/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
 </configuration>


### PR DESCRIPTION
Agent service is able to run under .NET framework 4.5 and thus allowing it to run on Windows Server 2012 and Windows 8 is without updating .NET.

[Ref pull request](https://github.com/Microsoft/vsts-agent/pull/851)