### PR TITLE
update agent to m117 version of vss-api-netcore

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.42-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.43-private" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.42-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.43-private" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />

--- a/src/Agent.Worker/TestResults/TrxResultReader.cs
+++ b/src/Agent.Worker/TestResults/TrxResultReader.cs
@@ -129,6 +129,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     {
                         IdentityRef ownerIdRef = new IdentityRef();
                         ownerIdRef.DisplayName = ownerNode.Attributes["name"].Value;
+                        ownerIdRef.DirectoryAlias = ownerNode.Attributes["name"].Value;
                         owner = ownerIdRef;
                     }
 

--- a/src/Agent.Worker/TestResults/XunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/XunitResultReader.cs
@@ -214,6 +214,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     {
                         IdentityRef ownerIdRef = new IdentityRef();
                         ownerIdRef.DisplayName = ownerNode.Attributes["value"].Value;
+                        ownerIdRef.DirectoryAlias = ownerNode.Attributes["value"].Value;
                         resultCreateModel.Owner = ownerIdRef;
                     }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         public static class Agent
         {
-            public static readonly string Version = "2.116.1";
+            public static readonly string Version = "2.117.0";
 
 #if OS_LINUX
             public static readonly OSPlatform Platform = OSPlatform.Linux;

--- a/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
+++ b/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.42-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.43-private" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.42-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.43-private" />
     <PackageReference Include="Moq" Version="4.6.36-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
update agent to m117 version of vss-api-netcore
publish test result can now use Directoryalias for owner field for individual and groups alias.