### PR TITLE
download rollback jenkins commits

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/JenkinsArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/JenkinsArtifact.cs
@@ -117,11 +117,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                         }
                         else if (startJobId > endJobId)
                         {
-                            context.Output(StringUtil.Loc("JenkinsRollbackDeployment"));
-                            int swap=startJobId;
-                            startJobId=endJobId;
-                            endJobId=swap;
-                            //swap the job IDs to fetch the roll back commits
+                            context.Output(StringUtil.Loc("JenkinsRollbackDeployment", startJobId, endJobId));
+                            // swap the job IDs to fetch the roll back commits
+                            int swap = startJobId;
+                            startJobId = endJobId;
+                            endJobId = swap;
                         }
                         else if (startJobId == endJobId)
                         {

--- a/src/Agent.Worker/Release/Artifacts/JenkinsArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/JenkinsArtifact.cs
@@ -118,10 +118,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                         else if (startJobId > endJobId)
                         {
                             context.Output(StringUtil.Loc("JenkinsRollbackDeployment"));
-
-                            // we do not support fetching the commits for the rollback deployment fully yet.
-                            // until then we will return from here.
-                            return;
+                            int swap=startJobId;
+                            startJobId=endJobId;
+                            endJobId=swap;
+                            //swap the job IDs to fetch the roll back commits
                         }
                         else if (startJobId == endJobId)
                         {

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -154,7 +154,7 @@
   "JenkinsCommitsInvalidEndJobId": "EndJobId {0} associated with the jenkins artifact {1} is invalid. Commits will not be downloaded.",
   "JenkinsDownloadingChangeFromCurrentBuild": "Cannot find endJobId, will be fetching the current build's changeset",
   "JenkinsNoCommitsToFetch": "Deploying same build. Nothing to fetch",
-  "JenkinsRollbackDeployment": "This is a Rollback deployment",
+  "JenkinsRollbackDeployment": "Downloading commits for Rollback Deployment between job {0} to {1}",
   "JobCompleted": "{0:u}: Job {1} completed with result: {2}",
   "ListenerHelp": [
     "Visual Studio Team Services Agent",

--- a/src/Test/L0/Worker/Release/JenkinsArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/JenkinsArtifactL0.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
         [Fact]
         [TraitAttribute("Level", "L0")]
         [TraitAttribute("Category", "Worker")]
-        public async void JenkinsRollbackCommitsNotSupported()
+        public async void JenkinsRollbackCommitsShouldBeFetched()
         {
             using (TestHostContext tc = Setup())
             {
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
                 string expectedUrl = $"{details.Url}/job/{details.JobName}/api/json?tree=builds[number,result,changeSet[items[commitId,date,msg,author[fullName]]]]{{0,1}}";
 
                 await artifact.DownloadCommitsAsync(_ec.Object, _artifactDefinition, tc.GetDirectory(WellKnownDirectory.Root));
-                _httpClient.Verify(x => x.GetStringAsync(It.Is<string>(y => y.StartsWith(expectedUrl)), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+                _httpClient.Verify(x => x.GetStringAsync(It.Is<string>(y => y.StartsWith(expectedUrl)), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
             }
         }
         [Fact]


### PR DESCRIPTION
Jenkins commits should be downloaded even for rollback releases.