### PR TITLE
Do not cache SVN credentials on agent machine

### DIFF
--- a/src/Agent.Worker/Build/SvnCommandManager.cs
+++ b/src/Agent.Worker/Build/SvnCommandManager.cs
@@ -547,6 +547,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 formattedArgs.Add(QuotedArgument(_password));
             }
 
+            formattedArgs.Add("--no-auth-cache"); // Do not cache credentials
             formattedArgs.Add("--non-interactive");
 
             // Add proxy setting parameters


### PR DESCRIPTION
The agent currently passes credentials to svn via the command line and by default svn caches credentials on-disk.  This change prevents that by passing the **--no-auth-cache** argument to svn.