### PR TITLE
Update windows tracing documentation

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,7 +55,7 @@ Set the environment variable before you launch the agent.listener
 
 ### Steps
 1. Open cmd.exe and browse to your Agent folder.
-2. Set the Agent to use Fiddler as a proxy
+2. Set the Agent to use Fiddler as a proxy.
 ```bash
 \vsts-agent> set VSTS_HTTP_PROXY=http://127.0.0.1:8888
 ```
@@ -63,12 +63,11 @@ Type set again and ensure that the variable is there.
 
 NOTE: This is scoped to your current window. If you start again from a new cmd you will need to set this again. If you are running the Agent as a service you can set an environment variable with the same name and value.
 
-3. Navigate to the _layout folder and type run
+3. Navigate to the _layout folder and type run to start the agent.
 ```bash
 \vsts-agent> cd _layout
 \vsts-agent\_layout> run
 ```
-The agent is now running.
 
 4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler coming from the agent.worker Process.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,9 +49,9 @@ Set the environment variable before you launch the agent.listener
 2. Turn off file capture (File > Capture Traffic)
 3. Enable decrypting HTTPS traffic (Tools > Fiddler Options > HTTPS tab. Check Decrypt HTTPS traffic)
 4. If your agent is pointing to localhost, you must reconfigure.
-a. Navigate to your _layout folder in cmd
-b. Type config remove and hit enter
-c. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
+    a. Navigate to your _layout folder in cmd
+    b. Type config remove and hit enter
+    c. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
 
 ### Steps
 1. Open cmd.exe and browse to your Agent folder.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,6 +62,7 @@ set VSTS_HTTP_PROXY=http://127.0.0.1:8888
 Type set again and ensure that the variable is there.
 
 NOTE: This is scoped to your current window. If you start again from a new cmd you will need to set this again. If you are running the Agent as a service you can set an environment variable with the same name and value.
+
 3. Navigate to the _layout folder and type run
 ```bash
 cd _layout

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,7 +51,7 @@ Set the environment variable before you launch the agent.listener
 4. If your agent is pointing to localhost, you must reconfigure.
     1. Navigate to your _layout folder in cmd
     2. Type config remove and hit enter
-    3. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
+    3. Type config to reset the agent. When you set the endpoint, you must set it as http://---your-machine-name---:8080/tfs, not http://localhost:8080/tfs.
 
 ### Steps
 1. Open cmd.exe and browse to your Agent folder.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,7 +49,7 @@ Set the environment variable before you launch the agent.listener
 2. Turn off file capture (File > Capture Traffic)
 3. Enable decrypting HTTPS traffic (Tools > Fiddler Options > HTTPS tab. Check Decrypt HTTPS traffic)
 4. If your agent is pointing to localhost, you must reconfigure.
-    a. Navigate to your _layout folder in cmd
+    1. Navigate to your _layout folder in cmd
     b. Type config remove and hit enter
     c. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,7 +69,8 @@ NOTE: This is scoped to your current window. If you start again from a new cmd y
 \vsts-agent\_layout> run
 ```
 The agent is now running.
-4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler coming from a Process of agent.worker.
+
+4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler coming from the agent.worker Process.
 
 ### Potentially Helpful Hints
 1. If you don't see the Process column in Fiddler, restart and while it's loading hold Shift. This will reset the UI.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,21 +44,39 @@ Set the environment variable before you launch the agent.listener
 
 ## (Alternate) Http Tracing Windows
 
-Start [Fiddler](http://www.telerik.com/fiddler).  
-It's recommended to only listen to agent traffic.  File > Capture Traffic off (F12)  
-Enable decrypting HTTPS traffic.  Tools > Fiddler Options > HTTPS tab. Decrypt HTTPS traffic
+### Prerequisites
+1. Download and install [Fiddler](http://www.telerik.com/fiddler).
+2. Turn off file capture
+File > Capture Traffic off (F12)  
+---insert pic---
+3. Enable decrypting HTTPS traffic
+Tools > Fiddler Options > HTTPS tab. Decrypt HTTPS traffic
+---insert pic---
+4. If your agent is pointing to localhost, you must reconfigure.
+a. Navigate to your _layout folder in cmd
+b. Type config remove and hit enter
+c. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
 
-Let the agent know to use the proxy:
-
+### Steps
+1. Open cmd.exe and browse to your Agent folder.
+2. Set the Agent to use Fiddler as a proxy
 ```bash
 set VSTS_HTTP_PROXY=http://127.0.0.1:8888
 ```
+Type set again and ensure that the variable is there.
 
-Run the agent interactively.  If you're running as a service, you can set as the environment variable in control panel for the account the service is running as.
+NOTE: This is scoped to your current window. If you start again from a new cmd you will need to set this again. If you are running the Agent as a service you can set an environment variable with the same name and value.
+3. Navigate to the _layout folder and type run
+```bash
+cd _layout
+run
+```
+The agent is now running.
+4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler that look something like:
+---insert pic here---
 
-Restart the agent.
-
-TODO: video
+### Potentially Helpful Hints
+1. If you don't see the Process column in Fiddler, restart and while it's loading hold Shift. This will reset the UI.
 
 ## (Alternate) Http Tracing OSX / Linux
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,8 +50,8 @@ Set the environment variable before you launch the agent.listener
 3. Enable decrypting HTTPS traffic (Tools > Fiddler Options > HTTPS tab. Check Decrypt HTTPS traffic)
 4. If your agent is pointing to localhost, you must reconfigure.
     1. Navigate to your _layout folder in cmd
-    b. Type config remove and hit enter
-    c. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
+    2. Type config remove and hit enter
+    3. Type config to reset the agent. When you set the endpoint, you must set it as http://<your-machine-name>:8080/tfs, not http://localhost:8080/tfs.
 
 ### Steps
 1. Open cmd.exe and browse to your Agent folder.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,7 +57,7 @@ Set the environment variable before you launch the agent.listener
 1. Open cmd.exe and browse to your Agent folder.
 2. Set the Agent to use Fiddler as a proxy
 ```bash
-set VSTS_HTTP_PROXY=http://127.0.0.1:8888
+\vsts-agent> set VSTS_HTTP_PROXY=http://127.0.0.1:8888
 ```
 Type set again and ensure that the variable is there.
 
@@ -65,8 +65,8 @@ NOTE: This is scoped to your current window. If you start again from a new cmd y
 
 3. Navigate to the _layout folder and type run
 ```bash
-cd _layout
-run
+\vsts-agent> cd _layout
+\vsts-agent\_layout> run
 ```
 The agent is now running.
 4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler coming from a Process of agent.worker.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,7 +51,7 @@ Set the environment variable before you launch the agent.listener
 4. If your agent is pointing to localhost, you must reconfigure.
     1. Navigate to your _layout folder in cmd
     2. Type config remove and hit enter
-    3. Type config to reset the agent. When you set the endpoint, you must set it as http://---your-machine-name---:8080/tfs, not http://localhost:8080/tfs.
+    3. Type config to reset the agent. When you set the endpoint, you must set it as http://{your-machine-name}:8080/tfs, not http://localhost:8080/tfs.
 
 ### Steps
 1. Open cmd.exe and browse to your Agent folder.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,12 +46,8 @@ Set the environment variable before you launch the agent.listener
 
 ### Prerequisites
 1. Download and install [Fiddler](http://www.telerik.com/fiddler).
-2. Turn off file capture
-File > Capture Traffic off (F12)  
----insert pic---
-3. Enable decrypting HTTPS traffic
-Tools > Fiddler Options > HTTPS tab. Decrypt HTTPS traffic
----insert pic---
+2. Turn off file capture (File > Capture Traffic)
+3. Enable decrypting HTTPS traffic (Tools > Fiddler Options > HTTPS tab. Check Decrypt HTTPS traffic)
 4. If your agent is pointing to localhost, you must reconfigure.
 a. Navigate to your _layout folder in cmd
 b. Type config remove and hit enter
@@ -72,8 +68,7 @@ cd _layout
 run
 ```
 The agent is now running.
-4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler that look something like:
----insert pic here---
+4. You can now do things in VSTS and see the requests that come from the Agent. A good example is queueing a new build. After you do that you should see requests in Fiddler coming from a Process of agent.worker.
 
 ### Potentially Helpful Hints
 1. If you don't see the Process column in Fiddler, restart and while it's loading hold Shift. This will reset the UI.


### PR DESCRIPTION
Update our documentation that describes how to monitor HTTP traffic from the Agent using Fiddler.