### PR TITLE
Add quotes to agent service install path.

### DIFF
--- a/src/Agent.Listener/Configuration/NativeWindowsServiceHelper.cs
+++ b/src/Agent.Listener/Configuration/NativeWindowsServiceHelper.cs
@@ -445,7 +445,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         {
             Trace.Entering();
 
-            string agentServiceExecutable = Path.Combine(IOUtil.GetBinPath(), WindowsServiceControlManager.WindowsServiceControllerName);
+            string agentServiceExecutable = "\"" + Path.Combine(IOUtil.GetBinPath(), WindowsServiceControlManager.WindowsServiceControllerName) + "\"";
             IntPtr scmHndl = IntPtr.Zero;
             IntPtr svcHndl = IntPtr.Zero;
             IntPtr tmpBuf = IntPtr.Zero;


### PR DESCRIPTION
This is in reference to #1048 .

There is a vulnerability when our service is registered with a non-quoted path.

This change adds quotes to the path when the Agent is registered as a service.

Before:

![image](https://user-images.githubusercontent.com/450490/29177722-72063948-7dbd-11e7-9b0c-3c8a15fb9a48.png)

After:

![image](https://user-images.githubusercontent.com/450490/29177729-76464c50-7dbd-11e7-916c-a1f0bb974ed2.png)
