### PR TITLE
Users/stfrance/add containerfetch timeout envvar

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
@@ -236,6 +236,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                     DownloadBufferSize = executionContext.Variables.Release_Download_BufferSize ?? ContainerFetchEngineDefaultOptions.DownloadBufferSize
                 };
 
+                int fetchEngineAsyncTimeoutSeconds;
+                if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_FETCHENGINE_ASYNCTIMEOUT") ?? string.Empty, out fetchEngineAsyncTimeoutSeconds))
+                {
+                    // set the timeout max but make sure it's between [100, 1200]
+                    containerFetchEngineOptions.GetFileAsyncTimeout = TimeSpan.FromSeconds(Math.Min(Math.Max(fetchEngineAsyncTimeoutSeconds, 100), 1200));
+                } 
+                else 
+                {
+                    containerFetchEngineOptions.GetFileAsyncTimeout = ContainerFetchEngineDefaultOptions.GetFileAsyncTimeout;
+                }
+
                 executionContext.Output(StringUtil.Loc("RMParallelDownloadLimit", containerFetchEngineOptions.ParallelDownloadLimit));
                 executionContext.Output(StringUtil.Loc("RMDownloadBufferSize", containerFetchEngineOptions.DownloadBufferSize));
 

--- a/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
@@ -237,11 +237,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                 };
 
                 int fetchEngineTimeoutSeconds;
-                if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_FETCHENGINE_TIMEOUT") ?? string.Empty, out fetchEngineTimeoutSeconds))
+                if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_HTTP_TIMEOUT") ?? string.Empty, out fetchEngineTimeoutSeconds))
                 {
                     // set the timeout max but make sure it's between [100, 1200]
                     containerFetchEngineOptions.GetFileAsyncTimeout = TimeSpan.FromSeconds(Math.Min(Math.Max(fetchEngineTimeoutSeconds, 100), 1200));
-                } 
+                }
                 else 
                 {
                     containerFetchEngineOptions.GetFileAsyncTimeout = ContainerFetchEngineDefaultOptions.GetFileAsyncTimeout;

--- a/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
@@ -236,11 +236,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                     DownloadBufferSize = executionContext.Variables.Release_Download_BufferSize ?? ContainerFetchEngineDefaultOptions.DownloadBufferSize
                 };
 
-                int fetchEngineAsyncTimeoutSeconds;
-                if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_FETCHENGINE_ASYNCTIMEOUT") ?? string.Empty, out fetchEngineAsyncTimeoutSeconds))
+                int fetchEngineTimeoutSeconds;
+                if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_FETCHENGINE_TIMEOUT") ?? string.Empty, out fetchEngineTimeoutSeconds))
                 {
                     // set the timeout max but make sure it's between [100, 1200]
-                    containerFetchEngineOptions.GetFileAsyncTimeout = TimeSpan.FromSeconds(Math.Min(Math.Max(fetchEngineAsyncTimeoutSeconds, 100), 1200));
+                    containerFetchEngineOptions.GetFileAsyncTimeout = TimeSpan.FromSeconds(Math.Min(Math.Max(fetchEngineTimeoutSeconds, 100), 1200));
                 } 
                 else 
                 {
@@ -249,6 +249,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
 
                 executionContext.Output(StringUtil.Loc("RMParallelDownloadLimit", containerFetchEngineOptions.ParallelDownloadLimit));
                 executionContext.Output(StringUtil.Loc("RMDownloadBufferSize", containerFetchEngineOptions.DownloadBufferSize));
+                executionContext.Output(StringUtil.Loc("RMContainerFetchTimeout", containerFetchEngineOptions.GetFileAsyncTimeout.Seconds));
 
                 IContainerProvider containerProvider =
                     new ContainerProviderFactory(buildArtifactDetails, rootLocation, containerId, executionContext).GetContainerProvider(

--- a/src/Agent.Worker/Release/ContainerFetchEngine/FetchEngine.cs
+++ b/src/Agent.Worker/Release/ContainerFetchEngine/FetchEngine.cs
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
 
                     if (!getFileTask.IsCompleted)
                     {
-                        throw new TimeoutException(StringUtil.Loc("RMGetFileAsyncTimedOut", GetFileAsyncTimeoutMinutes));
+                        throw new TimeoutException(StringUtil.Loc("RMGetFileAsyncTimedOut", ContainerFetchEngineOptions.GetFileAsyncTimeout.Seconds));
                     }
 
                     ExecutionLogger.Debug(StringUtil.Format("Writing contents of file {0} to disk", tmpDownloadPath));
@@ -393,7 +393,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
         private static readonly TimeSpan ProgressInterval = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan TaskDiagThreshold = TimeSpan.FromMinutes(1);
 
-        private const int GetFileAsyncTimeoutMinutes = 5;
         public ContainerFetchEngineOptions ContainerFetchEngineOptions { get; set; }
     }
 }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -428,6 +428,7 @@
   "RMCachingAllItems": "Caching all items in the file container...",
   "RMCachingComplete": "Caching complete. ({0} ms)",
   "RMCachingContainerItems": "Caching items under '{0}' in the file container...",
+  "RMContainerFetchTimeout": "Container fetch timeout: {0}",
   "RMContainerItemNotSupported": "Container Item type '{0}' not supported.",
   "RMContainerItemPathDoesnotExist": "File container item path doesn't start with {0}: {1}",
   "RMContainerItemRequestTimedOut": "Request timed out after {0} seconds; sleeping for {1} seconds and attempting again. Request: {2} {3}",


### PR DESCRIPTION
This is in reference to #1030 

I added a new environment variable that can override the GetFileAsyncTimeout for the ContainerFetchEngine.

@GitHubSriramB please review and see if this is an appropriate solution.