### PR TITLE
Update Xamarin capability provider to work with VS 2017

### DIFF
--- a/src/Misc/layoutbin/powershell/Add-XamarinAndroidCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-XamarinAndroidCapabilities.ps1
@@ -9,7 +9,7 @@ if (!(Add-CapabilityFromRegistry -Name 'Xamarin.Android' -Hive 'LocalMachine' -V
         $xamarinAndroidDir = ([System.IO.Path]::Combine($shellFolder15, 'MSBuild', 'Xamarin', 'Android')) + '\'
         if ((Test-Container -LiteralPath $xamarinAndroidDir)) {
             $versionFile = ([System.IO.Path]::Combine($xamarinAndroidDir, 'Version'))
-            $version = Get-Content -erroraction ignore -totalcount 1 $versionFile 
+            $version = Get-Content -ErrorAction ignore -TotalCount 1 -LiteralPath $versionFile 
             if ($version) {
                 Write-Capability -Name 'Xamarin.Android' -Value $version.trim()
             }

--- a/src/Misc/layoutbin/powershell/Add-XamarinAndroidCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-XamarinAndroidCapabilities.ps1
@@ -1,4 +1,19 @@
 [CmdletBinding()]
 param()
 
-$null = Add-CapabilityFromRegistry -Name 'Xamarin.Android' -Hive 'LocalMachine' -View 'Registry32' -KeyName 'Software\Novell\Mono for Android' -ValueName 'InstalledVersion'
+if (!(Add-CapabilityFromRegistry -Name 'Xamarin.Android' -Hive 'LocalMachine' -View 'Registry32' -KeyName 'Software\Novell\Mono for Android' -ValueName 'InstalledVersion')) {
+    $vs15 = Get-VisualStudio_15_0
+    if ($vs15 -and $vs15.installationPath) {
+        # End with "\" for consistency with old ShellFolder values.
+        $shellFolder15 = $vs15.installationPath.TrimEnd('\'[0]) + "\"
+        $xamarinAndroidDir = ([System.IO.Path]::Combine($shellFolder15, 'MSBuild', 'Xamarin', 'Android')) + '\'
+        if ((Test-Container -LiteralPath $xamarinAndroidDir)) {
+            $versionFile = ([System.IO.Path]::Combine($xamarinAndroidDir, 'Version'))
+            $version = Get-Content $versionFile
+            if ($version) {
+                Write-Capability -Name 'Xamarin.Android' -Value $version
+            }
+        }
+    }
+}
+

--- a/src/Misc/layoutbin/powershell/Add-XamarinAndroidCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-XamarinAndroidCapabilities.ps1
@@ -9,9 +9,9 @@ if (!(Add-CapabilityFromRegistry -Name 'Xamarin.Android' -Hive 'LocalMachine' -V
         $xamarinAndroidDir = ([System.IO.Path]::Combine($shellFolder15, 'MSBuild', 'Xamarin', 'Android')) + '\'
         if ((Test-Container -LiteralPath $xamarinAndroidDir)) {
             $versionFile = ([System.IO.Path]::Combine($xamarinAndroidDir, 'Version'))
-            $version = Get-Content $versionFile
+            $version = Get-Content -erroraction ignore -totalcount 1 $versionFile 
             if ($version) {
-                Write-Capability -Name 'Xamarin.Android' -Value $version
+                Write-Capability -Name 'Xamarin.Android' -Value $version.trim()
             }
         }
     }


### PR DESCRIPTION
Stop gap solution before we finalize on how to package vssetup powershell module.  This should work for existing Xamarin installations and doesn't introduce new dependency.