### PR TITLE
Fixing initialization of the attachment root folder to pick from the TRX folder

### DIFF
--- a/src/Agent.Worker/TestResults/TrxResultReader.cs
+++ b/src/Agent.Worker/TestResults/TrxResultReader.cs
@@ -33,8 +33,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         public TestRunData ReadResults(IExecutionContext executionContext, string filePath, TestRunContext runContext)
         {
             _executionContext = executionContext;
-            _attachmentLocation = Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath), "In");
-            _executionContext.Debug(string.Format(CultureInfo.InvariantCulture, "Attachment location: {0}", _attachmentLocation));
 
             _definitions = new Dictionary<string, TestCaseDefinition>();
 
@@ -102,6 +100,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 releaseUri: runContext.ReleaseUri,
                 releaseEnvironmentUri: runContext.ReleaseEnvironmentUri
                 );
+
+            //Parse the Deployment node for the runDeploymentRoot - this is the attachment root. 
+            XmlNode deploymentNode = doc.SelectSingleNode("/TestRun/TestSettings/Deployment");
+            var _attachmentRoot = string.Empty;
+            if (node != null && deploymentNode.Attributes["runDeploymentRoot"] != null )
+            {
+                _attachmentRoot = deploymentNode.Attributes["runDeploymentRoot"].Value;
+            }
+            else
+            {
+                _attachmentRoot = Path.GetFileNameWithoutExtension(filePath);
+            }
+            _attachmentLocation = Path.Combine(Path.GetDirectoryName(filePath), _attachmentRoot, "In");
+            _executionContext.Debug(string.Format(CultureInfo.InvariantCulture, "Attachment location: {0}", _attachmentLocation));
 
             AddRunLevelAttachments(filePath, doc, testRunData);
 

--- a/src/Agent.Worker/TestResults/TrxResultReader.cs
+++ b/src/Agent.Worker/TestResults/TrxResultReader.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             //Parse the Deployment node for the runDeploymentRoot - this is the attachment root. 
             XmlNode deploymentNode = doc.SelectSingleNode("/TestRun/TestSettings/Deployment");
             var _attachmentRoot = string.Empty;
-            if (node != null && deploymentNode.Attributes["runDeploymentRoot"] != null )
+            if (deploymentNode != null && deploymentNode.Attributes["runDeploymentRoot"] != null )
             {
                 _attachmentRoot = deploymentNode.Attributes["runDeploymentRoot"].Value;
             }


### PR DESCRIPTION
In .NET Core test, the assumption that the attachment root is the same as trx name is broken and hence we need to look at this property
TestRun\TestSettings\DeploymentR@runDeploymentRoot