### PR TITLE
Set domain to current machine when not explicit.

### DIFF
--- a/src/Agent.Listener/Configuration/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/WindowsServiceControlManager.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             if ((string.IsNullOrEmpty(domainName) || domainName.Equals(".", StringComparison.CurrentCultureIgnoreCase)) && !logonAccount.Contains('@'))
             {
                 logonAccount = String.Format("{0}\\{1}", Environment.MachineName, userName);
+                domainName = Environment.MachineName;
             }
 
             Trace.Info("LogonAccount after transforming: {0}, user: {1}, domain: {2}", logonAccount, userName, domainName);


### PR DESCRIPTION
_**Background**_

This fix is in reference to #722 . When configuring the agent if you use .\{user} it fails.

We want to support:

```bash
.\{user}
\{user}
```

_**Reproduction**_

vsts-agent\_layout>config

>> Connect:

Enter server URL > http://ZZZZZZZZZZ:8080/tfs
Enter authentication type (press enter for Integrated) >
Connecting to server ...

>> Register Agent:

Enter agent pool (press enter for default) >
Enter agent name (press enter for ZZZZZZZZZZ) >
Scanning for tool capabilities.
Connecting to the server.
Successfully added the agent
Testing agent connection.
Enter work folder (press enter for _work) >
2017-08-24 13:23:26Z: Settings Saved.
Enter run agent as service? (Y/N) (press enter for N) > y
Enter User account to use for the service (press enter for NT AUTHORITY\NETWORK SERVICE) > **.\Administrator**
Enter Password for the account ZZZZZZZZZZ\Administrator > **********
Cannot grant LogonAsService permission to the user ZZZZZZZZZZ\Administrator

_**Fix**_

When updating the login account for missing or . domain name, we need to update not only the logonAccount but also the domainName.

_**Fix Output**_

**#1**

Enter server URL > http://ZZZZZZZZZZ:8080/tfs
Enter authentication type (press enter for Integrated) >
Connecting to server ...

>> Register Agent:

Enter agent pool (press enter for default) >
Enter agent name (press enter for ZZZZZZZZZZ) >
Scanning for tool capabilities.
Connecting to the server.
Successfully added the agent
Testing agent connection.
Enter work folder (press enter for _work) >
2017-08-24 15:22:43Z: Settings Saved.
Enter run agent as service? (Y/N) (press enter for N) > y
Enter User account to use for the service (press enter for NT AUTHORITY\NETWORK SERVICE) > **.\Administrator**
Enter Password for the account ZZZZZZZZZZ\Administrator > **********
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ successfully installed
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ successfully set recovery option
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ successfully configured
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ started successfully

**#2**

vsts-agent\_layout>config

>> Connect:

Enter server URL > http://ZZZZZZZZZZ:8080/tfs
Enter authentication type (press enter for Integrated) >
Connecting to server ...

>> Register Agent:

Enter agent pool (press enter for default) >
Enter agent name (press enter for ZZZZZZZZZZ) >
Scanning for tool capabilities.
Connecting to the server.
Successfully added the agent
Testing agent connection.
Enter work folder (press enter for _work) >
2017-08-24 15:25:39Z: Settings Saved.
Enter run agent as service? (Y/N) (press enter for N) > y
Enter User account to use for the service (press enter for NT AUTHORITY\NETWORK SERVICE) > **\Administrator**
Enter Password for the account ZZZZZZZZZZ\Administrator > **********
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ successfully installed
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ successfully set recovery option
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ successfully configured
Service vstsagent.ZZZZZZZZZZ.ZZZZZZZZZZ started successfully
