### PR TITLE
Fixing robocopy failure when  build contain '/' as prefix in artifact name

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
@@ -119,6 +119,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                 var relativePath = artifactDefinition.Details.RelativePath;
 
                 dropLocation = Path.Combine(dropLocation.TrimEnd(trimChars), relativePath.Trim(trimChars));
+                downloadFolderPath = downloadFolderPath.TrimEnd(trimChars);
 
                 string robocopyArguments = "\"" + dropLocation + "\" \"" + downloadFolderPath + "\" /E /Z /NP /R:3";
                 if (verbose != true)


### PR DESCRIPTION
Fixing robocopy failure when  build contain '/' as prefix in artifact name