### PR TITLE
Correctly detect mono's MSBuild

### DIFF
--- a/src/Agent.Listener/Capabilities/NixCapabilitiesProvider.cs
+++ b/src/Agent.Listener/Capabilities/NixCapabilitiesProvider.cs
@@ -50,7 +50,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Capabilities
             builder.Check(name: "JDK", fileName: "javac");
             builder.Check(name: "make");
             builder.Check(name: "maven", fileName: "mvn");
-            builder.Check(name: "MSBuild", fileName: "xbuild");
+            builder.Check(
+                name: "MSBuild",
+                fileName: "msbuild",
+                filePaths: new string[] { 
+                    "/Library/Frameworks/Mono.framework/Commands/msbuild",
+                    "/Library/Frameworks/Mono.framework/Commands/xbuild"
+                });
             builder.Check(name: "node.js", fileName: "node");
             builder.Check(name: "node.js", fileName: "nodejs");
             builder.Check(name: "npm");


### PR DESCRIPTION
Mono 5.x and newer ship actual `msbuild` and deprecate the old `xbuild` utility.
It makes sense to default to using `msbuild` instead of `xbuild`.