### PR TITLE
Enabling publishing of standard error for failed test results.

### DIFF
--- a/src/Agent.Worker/TestResults/TestCaseResultData.cs
+++ b/src/Agent.Worker/TestResults/TestCaseResultData.cs
@@ -6,6 +6,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
     {
         public string ConsoleLog { get; set; }
 
+        public string StandardError { get; set; }
+
         public string[] Attachments { get; set; }
     }
 }

--- a/src/Agent.Worker/TestResults/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestRunPublisher.cs
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             Trace.Entering();
             if (string.IsNullOrWhiteSpace(stdErr) == false)
             {
-                const string stdErrFileName = "Standard_Error_0Output.log";
+                const string stdErrFileName = "Standard_Error_Output.log";
 
                 if (stdErr.Length <= TCM_MAX_FILESIZE)
                 {

--- a/src/Agent.Worker/TestResults/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestRunPublisher.cs
@@ -327,9 +327,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private TestAttachmentRequestModel GetStandardErrorAttachmentRequestModel(string stdErr)
         {
             Trace.Entering();
-            if (!string.IsNullOrWhiteSpace(stdErr))
+            if (string.IsNullOrWhiteSpace(stdErr) == false)
             {
-                string stdErrFileName = "Standard Error Output.log";
+                const string stdErrFileName = "Standard_Error_0Output.log";
 
                 if (stdErr.Length <= TCM_MAX_FILESIZE)
                 {

--- a/src/Agent.Worker/TestResults/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestRunPublisher.cs
@@ -105,6 +105,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     {
                         await _testResultsServer.CreateTestResultAttachmentAsync(attachmentRequestModel, _projectName, testRun.Id, testresults[j].Id, cancellationToken);
                     }
+
+                    // Upload standard error as attachment
+                    string standardError = testResults[i + j].StandardError;
+                    TestAttachmentRequestModel stdErrAttachmentRequestModel = GetStandardErrorAttachmentRequestModel(standardError);
+                    if (stdErrAttachmentRequestModel != null)
+                    {
+                        await _testResultsServer.CreateTestResultAttachmentAsync(stdErrAttachmentRequestModel, _projectName, testRun.Id, testresults[j].Id, cancellationToken);
+                    }
                 }
             }
 
@@ -310,6 +318,29 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 else
                 {
                     _executionContext.Warning(StringUtil.Loc("AttachmentExceededMaximum", consoleLogFileName));
+                }
+            }
+
+            return null;
+        }
+
+        private TestAttachmentRequestModel GetStandardErrorAttachmentRequestModel(string stdErr)
+        {
+            Trace.Entering();
+            if (!string.IsNullOrWhiteSpace(stdErr))
+            {
+                string stdErrFileName = "Standard Error Output.log";
+
+                if (stdErr.Length <= TCM_MAX_FILESIZE)
+                {
+                    byte[] bytes = System.Text.Encoding.UTF8.GetBytes(stdErr);
+                    string encodedData = Convert.ToBase64String(bytes);
+                    return new TestAttachmentRequestModel(encodedData, stdErrFileName, "",
+                        AttachmentType.ConsoleLog.ToString());
+                }
+                else
+                {
+                    _executionContext.Warning(StringUtil.Loc("AttachmentExceededMaximum", stdErrFileName));
                 }
             }
 

--- a/src/Agent.Worker/TestResults/TrxResultReader.cs
+++ b/src/Agent.Worker/TestResults/TrxResultReader.cs
@@ -384,7 +384,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
                 if (resultCreateModel.Outcome.Equals("Failed"))
                 {
-                    XmlNode errorMessage, errorStackTrace, consoleLog;
+                    XmlNode errorMessage, errorStackTrace, consoleLog, standardError;
 
                     if ((errorMessage = resultNode.SelectSingleNode("./Output/ErrorInfo/Message")) != null && !string.IsNullOrWhiteSpace(errorMessage.InnerText))
                     {
@@ -401,6 +401,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     if ((consoleLog = resultNode.SelectSingleNode("./Output/StdOut")) != null && !string.IsNullOrWhiteSpace(consoleLog.InnerText))
                     {
                         resultCreateModel.ConsoleLog = consoleLog.InnerText;
+                    }
+
+                    // standard error
+                    if ((standardError = resultNode.SelectSingleNode("./Output/StdErr")) != null && !string.IsNullOrWhiteSpace(standardError.InnerText))
+                    {
+                        resultCreateModel.StandardError = standardError.InnerText;
                     }
                 }
 

--- a/src/Test/L0/Worker/TestResults/TestRunPublisherTests.cs
+++ b/src/Test/L0/Worker/TestResults/TestRunPublisherTests.cs
@@ -387,6 +387,52 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             Assert.Equal(decodedData, testResultWithStandardError.StandardError);
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void PublishStandardErrorLogWithMultiupleResultsIsSuccessful()
+        {
+            SetupMocks();
+            ResetValues();
+
+            TestCaseResultData testResultWithStandardError1 = new TestCaseResultData();
+            testResultWithStandardError1.StandardError = "Publish standard error is successfully logged for result 1";
+
+            TestCaseResultData testResultWithStandardError2 = new TestCaseResultData();
+            testResultWithStandardError2.StandardError = "Publish standard error is successfully logged for result 2";
+
+            TestCaseResultData testResultWithNoStandardError = new TestCaseResultData();
+            testResultWithNoStandardError.StandardError = "";
+
+            TestCaseResultData testResultDefault = new TestCaseResultData();
+
+            List<TestCaseResultData> testResults = new List<TestCaseResultData>() { testResultWithStandardError1, testResultWithStandardError2, testResultWithNoStandardError, testResultDefault };
+
+            // execute publish task
+            _testRunData = _publisher.ReadResultsFromFile(_testRunContext, "filepath");
+            _publisher.StartTestRunAsync(_testRunData).Wait();
+            var testRun = new TestRun { Id = 1 };
+            _publisher.AddResultsAsync(testRun, testResults.ToArray()).Wait();
+            _publisher.EndTestRunAsync(_testRunData, 1).Wait();
+
+            // validate
+            Assert.Equal(_resultsLevelAttachments.Count, 2);
+            Assert.Equal(_resultsLevelAttachments[1].Count, 1);
+            Assert.Equal(_resultsLevelAttachments[2].Count, 1);
+            Assert.Equal(_resultsLevelAttachments[1][0].AttachmentType, AttachmentType.ConsoleLog.ToString());
+            Assert.Equal(_resultsLevelAttachments[2][0].AttachmentType, AttachmentType.ConsoleLog.ToString());
+
+            string encodedData1 = _resultsLevelAttachments[1][0].Stream;
+            byte[] bytes1 = Convert.FromBase64String(encodedData1);
+            string decodedData1 = System.Text.Encoding.UTF8.GetString(bytes1);
+            Assert.Equal(decodedData1, testResultWithStandardError1.StandardError);
+
+            string encodedData2 = _resultsLevelAttachments[2][0].Stream;
+            byte[] bytes2 = Convert.FromBase64String(encodedData2);
+            string decodedData2 = System.Text.Encoding.UTF8.GetString(bytes2);
+            Assert.Equal(decodedData2, testResultWithStandardError2.StandardError);
+        }
+
         public void Dispose()
         {
             try

--- a/src/Test/L0/Worker/TestResults/TrxResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/TrxResultReaderTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                  "</TestSettings>" +
 
                  "<Results>" +
-                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><StdErr>This is standard error message.</StdErr><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                      "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                    "</UnitTestResult>" +
 
@@ -231,6 +231,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
             Assert.Equal(runData.Results[0].Priority.ToString(), "1");
             Assert.Equal(runData.Results[0].ConsoleLog, "Show console log output.");
+            Assert.Equal(runData.Results[0].StandardError, "This is standard error message.");
             Assert.Equal(runData.Results[0].Attachments.Length, 1);
             Assert.True(runData.Results[0].Attachments[0].Contains("x.txt"));
 
@@ -290,7 +291,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                  "</TestSettings>" +
 
                  "<Results>" +
-                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
+                   "<UnitTestResult executionId = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" testId = \"f0d6b58f-dc08-9c0b-aab7-0a1411d4a346\" testName = \"TestMethod2\" computerName = \"SOMERANDOMCOMPUTERNAME\" duration = \"00:00:00.0834563\" startTime = \"2015-03-20T16:53:32.3099353+05:30\" endTime = \"2015-03-20T16:53:32.3939623+05:30\" testType = \"13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b\" outcome = \"Failed\" testListId = \"8c84fa94-04c1-424b-9868-57a2d4851a1d\" relativeResultsDirectory = \"48ec1e47-b9df-43b9-aef2-a2cc8742353d\" ><Output><StdOut>Show console log output.</StdOut><StdErr>This is standard error message.</StdErr><ErrorInfo><Message>Assert.Fail failed.</Message><StackTrace>at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21</StackTrace></ErrorInfo></Output>" +
                      "<ResultFiles><ResultFile path=\"DIGANR-DEV4\\x.txt\" /></ResultFiles>" +
                    "</UnitTestResult>" +
 
@@ -350,6 +351,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                 Assert.Equal(runData.Results[0].StackTrace, "at UnitTestProject4.UnitTest1.TestMethod2() in C:\\Users\\somerandomusername\\Source\\Repos\\Projectx\\UnitTestProject4\\UnitTestProject4\\UnitTest1.cs:line 21");
                 Assert.Equal(runData.Results[0].Priority.ToString(), "1");
                 Assert.Equal(runData.Results[0].ConsoleLog, "Show console log output.");
+                Assert.Equal(runData.Results[0].StandardError, "This is standard error message.");
                 Assert.Equal(runData.Results[0].Attachments.Length, 1);
                 Assert.True(runData.Results[0].Attachments[0].Contains("x.txt"));
 


### PR DESCRIPTION
- Adding support for publishing standard error logs for failed test results as attachments. 
- Standard output logs are already being published as attachments for failed test results.