### PR TITLE
Check for build tags case insensitively.

### DIFF
--- a/src/Agent.Worker/Build/BuildCommandExtension.cs
+++ b/src/Agent.Worker/Build/BuildCommandExtension.cs
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             BuildServer buildServer = new BuildServer(connection, projectId);
             var tags = await buildServer.AddBuildTag(buildId, buildTag, cancellationToken);
 
-            if (tags == null || !tags.Contains(buildTag))
+            if (tags == null || !tags.Any(t => t.Equals(buildTag, StringComparison.OrdinalIgnoreCase)))
             {
                 throw new Exception(StringUtil.Loc("BuildTagAddFailed", buildTag));
             }


### PR DESCRIPTION
#1194 

When adding a new tag with the same text but different casing as an existing tag we shouldn't throw an exception.

The existing tag won't get overwritten but that's not a problem.