### PR TITLE
Users/dsinghal/bugfixes1

### DIFF
--- a/src/Agent.Listener/Configuration/AutoLogonRegistryManager.cs
+++ b/src/Agent.Listener/Configuration/AutoLogonRegistryManager.cs
@@ -415,7 +415,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             {
                 public const string AutoLogon = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon";
                 public const string ShutdownReasonDomainPolicy = @"SOFTWARE\Policies\Microsoft\Windows NT\Reliability";
-                public const string LegalNotice = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon";
+                public const string LegalNotice = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon";
             }
 
             public class ValueNames


### PR DESCRIPTION
Bug fix for the issue when we are not showing any warning if the legal text is set on the machine.

Issue: It was due to the wrong subkey path. The ' ' (space) character was different and it was resulting in failure when we look for legal notice caption/text.