### PR TITLE
Fix StandardErrorPath logging to stdout.log

### DIFF
--- a/src/Misc/layoutbin/vsts.agent.plist.template
+++ b/src/Misc/layoutbin/vsts.agent.plist.template
@@ -17,7 +17,7 @@
     <key>StandardOutPath</key>
     <string>{{UserHome}}/Library/Logs/{{SvcName}}/stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>{{UserHome}}/Library/Logs/{{SvcName}}/stdout.log</string>
+    <string>{{UserHome}}/Library/Logs/{{SvcName}}/stderr.log</string>
     <key>EnvironmentVariables</key>
     <dict> 
       <key>VSTS_AGENT_SVC</key>


### PR DESCRIPTION
The StandardErrorPath was set to stdout.log it should be set to
something else like stderr.log.