### PR TITLE
Revert "replace oauth endpoint url (#1133)"

### DIFF
--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -272,26 +272,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 agent.Authorization.ClientId != Guid.Empty &&
                 agent.Authorization.AuthorizationUrl != null)
             {
-                // For TFS, we need make sure the Schema/Host/Port component of the authorization url also match configuration url.
-                // We can't do this for VSTS, since its SPS/TFS urls are different.
-                UriBuilder configServerUrl = new UriBuilder(agentSettings.ServerUrl);
-                UriBuilder authorizationUrl = new UriBuilder(agent.Authorization.AuthorizationUrl);
-                if (!UrlUtil.IsHosted(configServerUrl.Uri.AbsoluteUri) &&
-                    Uri.Compare(configServerUrl.Uri, authorizationUrl.Uri, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) != 0)
-                {
-                    authorizationUrl.Scheme = configServerUrl.Scheme;
-                    authorizationUrl.Host = configServerUrl.Host;
-                    authorizationUrl.Port = configServerUrl.Port;
-                    Trace.Info($"Replace authorization url's scheme://host:port component with agent configure url's scheme://host:port: '{authorizationUrl.Uri.AbsoluteUri}'.");
-                }
-
                 var credentialData = new CredentialData
                 {
                     Scheme = Constants.Configuration.OAuth,
                     Data =
                     {
                         { "clientId", agent.Authorization.ClientId.ToString("D") },
-                        { "authorizationUrl", authorizationUrl.Uri.AbsoluteUri },
+                        { "authorizationUrl", agent.Authorization.AuthorizationUrl.AbsoluteUri },
                     },
                 };
 

--- a/src/Agent.Listener/Configuration/OAuthCredential.cs
+++ b/src/Agent.Listener/Configuration/OAuthCredential.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.OAuth;
 using Microsoft.VisualStudio.Services.WebApi;
@@ -8,14 +7,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 {
     public class OAuthCredential : CredentialProvider
     {
-        public OAuthCredential()
+        public OAuthCredential() 
             : base(Constants.Configuration.OAuth)
         {
         }
 
         public override void EnsureCredential(
-            IHostContext context,
-            CommandSettings command,
+            IHostContext context, 
+            CommandSettings command, 
             String serverUrl)
         {
             // Nothing to verify here
@@ -25,30 +24,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         {
             var clientId = this.CredentialData.Data.GetValueOrDefault("clientId", null);
             var authorizationUrl = this.CredentialData.Data.GetValueOrDefault("authorizationUrl", null);
-
-            ArgUtil.NotNullOrEmpty(clientId, nameof(clientId));
-            ArgUtil.NotNullOrEmpty(authorizationUrl, nameof(authorizationUrl));
-
-            // For TFS, we need make sure the Schema/Host/Port component of the authorization url also match configuration url.
-            // We can't do this for VSTS, since its SPS/TFS urls are different.
-            var configStore = context.GetService<IConfigurationStore>();
-            if (configStore.IsConfigured())
-            {
-                UriBuilder configServerUrl = new UriBuilder(configStore.GetSettings().ServerUrl);
-                UriBuilder authorizationUrlBuilder = new UriBuilder(authorizationUrl);
-                if (!UrlUtil.IsHosted(configServerUrl.Uri.AbsoluteUri) &&
-                    Uri.Compare(configServerUrl.Uri, authorizationUrlBuilder.Uri, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) != 0)
-                {
-                    authorizationUrlBuilder.Scheme = configServerUrl.Scheme;
-                    authorizationUrlBuilder.Host = configServerUrl.Host;
-                    authorizationUrlBuilder.Port = configServerUrl.Port;
-
-                    var trace = context.GetTrace(nameof(OAuthCredential));
-                    trace.Info($"Replace authorization url's scheme://host:port component with agent configure url's scheme://host:port: '{authorizationUrlBuilder.Uri.AbsoluteUri}'.");
-
-                    authorizationUrl = authorizationUrlBuilder.Uri.AbsoluteUri;
-                }
-            }
 
             // We expect the key to be in the machine store at this point. Configuration should have set all of
             // this up correctly so we can use the key to generate access tokens.


### PR DESCRIPTION
This reverts commit ecda503e419858021670f39c17b5fda99edbfc0e.

The initial commit is trying to fix a problem that only one customer had, however the change might introduced a regression to most TFS on-prem customer.
I would like to revert this change for TFS 2018 RTM, and add the right fix for that one customer in next agent release from Master branch.