### PR TITLE
only hook up server certificate validator base on request. corefx wil…

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         public static class Agent
         {
-            public static readonly string Version = "2.125.0";
+            public static readonly string Version = "2.125.1";
 
 #if OS_LINUX
             public static readonly OSPlatform Platform = OSPlatform.Linux;

--- a/src/Microsoft.VisualStudio.Services.Agent/Util/ApiUtil.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Util/ApiUtil.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
             VssClientHttpRequestSettings.Default.ClientCertificateManager = certSetting;
-            VssClientHttpRequestSettings.Default.ServerCertificateValidationCallback = certSetting.ServerCertificateValidationCallback;
             VssHttpMessageHandler.DefaultWebProxy = proxySetting;
         }
 


### PR DESCRIPTION
…l throw PlatformNotSupportException on non-Windows platform with CURL not built for openssl. (OSX, Fedora based OS)