### PR TITLE
scope extraheader for git lfs to only the repo url

### DIFF
--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -637,7 +637,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
                     if (GitLfsUseAuthHeaderCmdlineArg)
                     {
-                        additionalLfsFetchArgs.Add($"-c http.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"");
+                        string authorityUrl = repositoryUrl.AbsoluteUri.Replace(repositoryUrl.PathAndQuery, string.Empty);
+                        additionalLfsFetchArgs.Add($"-c http.{authorityUrl}.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"");
                     }
                     else
                     {


### PR DESCRIPTION
This change scopes the extraheader argument for the git lfs command line to only apply for the repo url.