### PR TITLE
add fix for proxy within release

### DIFF
--- a/src/Agent.Worker/Release/ReleaseJobExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseJobExtension.cs
@@ -132,11 +132,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
             {
                 ServiceEndpoint vssEndpoint = executionContext.Endpoints.FirstOrDefault(e =>
                     string.Equals(e.Name, ServiceEndpoints.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
+
                 ArgUtil.NotNull(vssEndpoint, nameof(vssEndpoint));
                 ArgUtil.NotNull(vssEndpoint.Url, nameof(vssEndpoint.Url));
 
                 Trace.Info($"Connecting to {vssEndpoint.Url}/{TeamProjectId}");
-                var releaseServer = new ReleaseServer(vssEndpoint.Url, ApiUtil.GetVssCredential(vssEndpoint), TeamProjectId);
+
+                var connection = WorkerUtilities.GetVssConnection(executionContext);
+                var releaseServer = new ReleaseServer(vssEndpoint.Url, connection, TeamProjectId);
 
                 IList<AgentArtifactDefinition> releaseArtifacts = releaseServer.GetReleaseArtifactsFromService(ReleaseId).ToList();
                 IList<AgentArtifactDefinition> filteredReleaseArtifacts = FilterArtifactDefintions(releaseArtifacts);

--- a/src/Agent.Worker/Release/ReleaseServer.cs
+++ b/src/Agent.Worker/Release/ReleaseServer.cs
@@ -6,27 +6,28 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Clients;
 using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Contracts;
+using Microsoft.VisualStudio.Services.WebApi;
 
 namespace Agent.Worker.Release
 {
     public class ReleaseServer
     {
         private Uri _projectCollectionUrl;
-        private VssCredentials _credential;
+        private VssConnection _connection;
         private Guid _projectId;
 
         private ReleaseHttpClient _releaseHttpClient { get; }
 
-        public ReleaseServer(Uri projectCollection, VssCredentials credentials, Guid projectId)
+        public ReleaseServer(Uri projectCollection, VssConnection connection, Guid projectId)
         {
             ArgUtil.NotNull(projectCollection, nameof(projectCollection));
-            ArgUtil.NotNull(credentials, nameof(credentials));
+            ArgUtil.NotNull(connection, nameof(connection));
 
             _projectCollectionUrl = projectCollection;
-            _credential = credentials;
+            _connection = connection;
             _projectId = projectId;
 
-            _releaseHttpClient = new ReleaseHttpClient(projectCollection, credentials, new VssHttpRetryMessageHandler(3));
+            _releaseHttpClient = _connection.GetClient<ReleaseHttpClient>();
         }
 
         public IEnumerable<AgentArtifactDefinition> GetReleaseArtifactsFromService(int releaseId, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
BugFix 1140645: Downloading artifact fails when agent is behind proxy and uses client certificate