### PR TITLE
Fix SqlPackage capability search

### DIFF
--- a/src/Misc/layoutbin/powershell/Add-SqlPackageCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-SqlPackageCapabilities.ps1
@@ -137,7 +137,7 @@ function Get-SqlPacakgeFromDacDirectory {
 
 
     if (!(Test-Container -LiteralPath $dacDirectory)) {
-        continue
+        return
     }
 
     # Get the DAC version folders.


### PR DESCRIPTION
#1098 refactored this file and introduced an error in the function that looks for SqlPackage occurences in a DAC folder:

If the folder is not found in the container, the search function will continue instead of returning an empty result. This leads to the script failing and no capabilities gets added, even if found previously.