### PR TITLE
Update yamlgettingstarted.md

### DIFF
--- a/docs/preview/yamlgettingstarted-tasks.md
+++ b/docs/preview/yamlgettingstarted-tasks.md
@@ -37,9 +37,9 @@ steps:
   inputs:
     command: install
 - task: Npm@1
-  displayName: npm test
+  displayName: npm publish
   inputs:
-    command: test
+    command: publish
 ```
 
 ## Resiliency


### PR DESCRIPTION
The npm task in VSTS only accepts three commands right now on v1.

- install
- publish
- custom.

So using the command input test will not work, we should either use command: custom and add additional commandParameter or take the publish command as a simple example.