### PR TITLE
Update 'target' to 'queue'

### DIFF
--- a/docs/preview/yamlgettingstarted-phases.md
+++ b/docs/preview/yamlgettingstarted-phases.md
@@ -61,17 +61,17 @@ Example phases that build in parallel (no dependencies).
 ```yaml
 phases:
 - phase: Windows
-  target:
+  queue:
     demands: agent.os -eq Windows_NT
   steps:
   - script: echo hello from Windows
 - phase: macOS
-  target:
+  queue:
     demands: agent.os -eq Darwin
   steps:
   - script: echo hello from macOS
 - phase: Linux
-  target:
+  queue:
     demands: agent.os -eq Linux
   steps:
   - script: echo hello from Linux


### PR DESCRIPTION
Using `target` caused build errors.  I guess this was renamed to `queue`.