### PR TITLE
Fixing Nunit3Result reader: added missing check to update platform only when there's valid build

### DIFF
--- a/src/Agent.Worker/TestResults/NunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/NunitResultReader.cs
@@ -372,9 +372,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                             {
                                 hostname = environmentNode.Attributes["machine-name"].Value;
                             }
-                            if (environmentNode.Attributes["platform"] != null)
+                            if (environmentNode.Attributes["platform"] != null && runContext?.BuildId > 0)
                             {
-                                // override platform
+                                // override platform only if there's valid build
+                                // We cannot publish platform information without a valid build id.
                                 _platform = environmentNode.Attributes["platform"].Value;
                             }
                         }


### PR DESCRIPTION
- This was a miss from the Nunit2Result reader. Added the same check here, without this will not be able to publish the results in release def. without build artifacts.
- Added L0