### PR TITLE
Added Windows 10 Kit and UAP SDK capabilities detection

### DIFF
--- a/src/Misc/layoutbin/powershell/Add-WindowsKitCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-WindowsKitCapabilities.ps1
@@ -18,7 +18,8 @@ foreach ($valueName in $valueNames) {
     if ($splitInstallDirectory.Length -eq 0) {
         continue
     }
-
+	
+	# Format input version to support Windows "10" versioning (parsing needs major.minor[.build[.revision]] format)
 	$inputVersion = $splitInstallDirectory[-1]
 	if ($inputVersion -notcontains ".") {
 		$inputVersion += ".0"
@@ -36,10 +37,38 @@ foreach ($valueName in $valueNames) {
     }
 }
 
+# Add a capability for the max Windows Kit.
 if ($versionInfos.Length) {
     $maxInfo =
         $versionInfos |
         Sort-Object -Descending -Property Version |
         Select-Object -First 1
     Write-Capability -Name "WindowsKit" -Value $maxInfo.InstallDirectory
+}
+
+# Detect installed versions of Windows 10 Kit.
+$windowsUAPSdks = @( )
+$versionSubKeyNames =
+    Get-RegistrySubKeyNames -Hive 'LocalMachine' -View 'Registry32' -KeyName $rootsKeyName |
+    Where-Object { $_ -clike '*.*.*.*' }
+foreach ($versionSubKeyName in $versionSubKeyNames) {
+	# Parse the version.
+    $version = $null
+    if (!([System.Version]::TryParse($versionSubKeyName, [ref]$version))) {
+        continue
+    }
+
+	# Save the Windows UAP info (for sorting).
+    $windowsUAPSdks += New-Object psobject -Property @{
+        Version = $version
+    }
+}
+
+# Add a capability for the max UAP SDK.
+$maxWindowsUAPSdk =
+    $windowsUAPSdks |
+    Sort-Object -Property Version -Descending |
+    Select-Object -First 1
+if ($maxWindowsUAPSdk) {
+    Write-Capability -Name 'WindowsUAP' -Value $maxWindowsUAPSdk.Version
 }

--- a/src/Misc/layoutbin/powershell/Add-WindowsKitCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-WindowsKitCapabilities.ps1
@@ -19,8 +19,13 @@ foreach ($valueName in $valueNames) {
         continue
     }
 
+	$inputVersion = $splitInstallDirectory[-1]
+	if ($inputVersion -notcontains ".") {
+		$inputVersion += ".0"
+	}
+
     $version = $null
-    if (!([System.Version]::TryParse($splitInstallDirectory[-1], [ref]$version))) {
+    if (!([System.Version]::TryParse($inputVersion, [ref]$version))) {
         continue
     }
 


### PR DESCRIPTION
I see no proper capabilities detection since new Windows 10 versioning schema.

So I propose this implementation:

- Fixed Windows Kit detection for version 10;
- Added Windows UAP SDK capability with version of the last installed SDK.

I don't see the value of listing all the installed UAP SDK because only the last is referenced in the "Windows Kits\10\SDKManifest.xml" file. But I'm open to a proposition if someone see a value for this :)

Thanks!