### PR TITLE
Conditional expression support in source clean parameter.

### DIFF
--- a/src/Agent.Worker/Build/SourceProvider.cs
+++ b/src/Agent.Worker/Build/SourceProvider.cs
@@ -98,5 +98,25 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         {
             return false;
         }
+
+        public bool GetConditionLiteralBool(string value, out bool result)
+        {
+            switch (value.ToLowerInvariant())
+            {
+                case "1":
+                case "true":
+                case "$true":
+                    result = true;
+                    return true;
+                case "0":
+                case "false":
+                case "$false":
+                    result = false;
+                    return true;
+                default:
+                    result = false;
+                    return false;
+            }
+        }
     }
 }

--- a/src/Agent.Worker/Build/TfsVCSourceProvider.cs
+++ b/src/Agent.Worker/Build/TfsVCSourceProvider.cs
@@ -143,35 +143,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             
             if (endpoint.Data.ContainsKey(EndpointData.Clean))
             {
-                // Get an Expression Manager so we can evaluate conditions
-                var expressionManager = HostContext.GetService<IExpressionManager>();
-                try
+                if (!GetConditionLiteralBool(endpoint.Data[EndpointData.Clean], out clean))
                 {
-                    switch (endpoint.Data[EndpointData.Clean])
+                    var expressionManager = HostContext.GetService<IExpressionManager>();
+                    try
                     {
-                        case "1":
-                        case "true":
-                        case "$true":
-                            clean = true;
-                            break;
-                        case "0":
-                        case "false":
-                        case "$false":
-                            clean = false;
-                            break;
-                        default:
-                            clean = expressionManager.Evaluate(
-                                executionContext, expressionManager.Parse(executionContext, endpoint.Data[EndpointData.Clean])
-                                ).Value;
-                            break;
+                        clean = expressionManager.Evaluate(
+                            executionContext, expressionManager.Parse(executionContext, endpoint.Data[EndpointData.Clean])
+                            ).Value;
                     }
-                }
-                catch (Exception ex)
-                {
-                    Trace.Info("Caught exception from expression.");
-                    Trace.Error(ex);
-                    clean = false;
-                    executionContext.Error(ex);
+                    catch (Exception ex)
+                    {
+                        Trace.Info("Caught exception from expression.");
+                        Trace.Error(ex);
+                        clean = false;
+                        executionContext.Error(ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
We have a need in our environment to conditionally clean the source tree before doing a build in our CI.  Previously, we would do this as a final step in a build so it was clean for the next one.  However, true/false values can be generated for conditional execution elsewhere using expressions, so we added code in the agent to support it in the 'clean' field too.

Use case:

We generate our build numbers as a sequence using the date followed by a revision (".1" for first build of day, ".2" for second, etc).  We then use this as the clean parameter:
`endsWith(variables['Build.BuildNumber'], '.1')`