### PR TITLE
Also populate java in case user only has jdk installed

### DIFF
--- a/src/Misc/layoutbin/powershell/Add-JavaCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-JavaCapabilities.ps1
@@ -33,4 +33,8 @@ $null = Add-CapabilityFromRegistry -Name 'jdk_8_x64' -Hive 'LocalMachine' -View 
 if ($latestJdk) {
     # Favor x64.
     Write-Capability -Name 'jdk' -Value $latestJdk
+
+    if (!($latestJre)) {
+        Write-Capability -Name 'java' -Value $latestJdk
+    }
 }


### PR DESCRIPTION
If a user only has JDK installed, looks like Oracle doesn't populate the registry key for JRE anymore.  