### PR TITLE
vNext agent requires an update of .NET Framework

### DIFF
--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -8,7 +8,7 @@ No known system prerequisites are known at this time.
 
 [PowerShell 3.0 or higher](https://msdn.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell)
 
-[.NET Framework x64 4.5 or higher](https://www.microsoft.com/en-us/download/details.aspx?id=36359)
+[.NET Framework x64 4.5 or higher](https://docs.microsoft.com/en-us/dotnet/framework/install/)
 
 ## Visual Studio
 

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -7,6 +7,7 @@ No known system prerequisites are known at this time.
 ## Windows 7 to Windows 8.1, Windows Server 2008 R2 SP1 to Windows Server 2012 R2 (64-bit)
 
 [PowerShell 3.0 or higher](https://msdn.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell)
+[.NET Framework x64 4.5 or higher](https://www.microsoft.com/en-us/download/details.aspx?id=36359)
 
 ## Visual Studio
 

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -7,6 +7,7 @@ No known system prerequisites are known at this time.
 ## Windows 7 to Windows 8.1, Windows Server 2008 R2 SP1 to Windows Server 2012 R2 (64-bit)
 
 [PowerShell 3.0 or higher](https://msdn.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell)
+
 [.NET Framework x64 4.5 or higher](https://www.microsoft.com/en-us/download/details.aspx?id=36359)
 
 ## Visual Studio


### PR DESCRIPTION

On Windows 7 and 2008 R2 SP1 machines without .NET Framework 4.5 or higher installed the agent config step will display a message indicating that “.Net Framework x64 4.5 or higher is required”.

Screenshot is from a 2008 R2 SP1 machine without .NET Framework 4.5 (only the out of the box 4.0) installed. 

![win2008r2sp1withoutnet45](https://user-images.githubusercontent.com/9444698/40292159-1db312e0-5cb9-11e8-8760-7fae2ee43177.png)

I came across this due to a customer scenario where rolling up the .NET Framework version would trigger an internal process that would in turn trigger a full regression test of legacy systems. The team rolling out a TFS upgrade in the organisation would like to avoid this scenario and has asked me if I can suggest an update to the docs to make clear, that .NET Framework 4.0 is not supported in conjunction with the vNext agent. 