### PR TITLE
Reading owner attribute from junit xml And not using context owner as test case owner

### DIFF
--- a/src/Agent.Worker/TestResults/JunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/JunitResultReader.cs
@@ -235,6 +235,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                         resultCreateModel.AutomatedTestStorage = testCaseNode.Attributes["classname"].Value;
                     }
 
+                    if (testCaseNode.Attributes["owner"]?.Value != null)
+                    {
+                        var ownerName = testCaseNode.Attributes["owner"].Value;
+                        resultCreateModel.Owner = new IdentityRef { DisplayName = ownerName, DirectoryAlias = ownerName };
+                    }
+
                     //test case duration
                     bool TestCaseTimeDataAvailable = false;
                     var testCaseDuration = GetTimeSpan(testCaseNode, out TestCaseTimeDataAvailable);
@@ -280,7 +286,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     if (runUserIdRef != null)
                     {
                         resultCreateModel.RunBy = runUserIdRef;
-                        resultCreateModel.Owner = runUserIdRef;
                     }
 
                     if (!string.IsNullOrEmpty(resultCreateModel.AutomatedTestName) && !string.IsNullOrEmpty(resultCreateModel.TestCaseTitle))


### PR DESCRIPTION
- Reading the testcase attribute from junit xml as the test case owner.
- Earlier we were setting the context owner, build or the release woner as the owner of test case also.
- So removing it as that's not correct.
- L0