### PR TITLE
Document that phase: is required under phases:

### DIFF
--- a/docs/preview/yamlgettingstarted-schema.md
+++ b/docs/preview/yamlgettingstarted-schema.md
@@ -109,8 +109,9 @@ steps: [ script | powershell | bash | task | stepsPhase | stepsTemplateReference
 #### phase
 
 ```yaml
+phase: string # Required
+
 displayName: string
-name: string
 dependsOn: string | [ string ]
 condition: string
 continueOnError: true | false


### PR DESCRIPTION
Without a

```yaml
phase:
```

key in the `phases` list, I got errors like

```
.vsts-dotnet.yml (Line: 2, Col: 3): Unexpected value 'queue'
.vsts-dotnet.yml Unexpected state while attempting to read the next mapping key. Object state: (Depth: 4, Current: 'YamlMapping', Is start: True, Parent: 'YamlMapping', Index: 1, Is key: False)
```