### PR TITLE
Allow config.sh to run as root.

### DIFF
--- a/src/Misc/layoutroot/config.sh
+++ b/src/Misc/layoutroot/config.sh
@@ -3,7 +3,7 @@
 user_id=`id -u`
 
 # we want to snapshot the environment of the config user
-if [ $user_id -eq 0 ]; then
+if [ $user_id -eq 0 ] && [ "${ALLOW_RUNASROOT:-default_value}" == "default_value" ]; then
     echo "Must not run with sudo"
     exit 1
 fi


### PR DESCRIPTION
Environment variable ALLOW_RUNASROOT overrides the default behavior of config.sh as per Issue #1481.

Example: `export ALLOW_RUNASROOT=1; ./config.sh --unattended`