### PR TITLE
Fixing invalid startdate for test run being sent from Publish test results task

### DIFF
--- a/src/Agent.Worker/TestResults/JunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/JunitResultReader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         public TestRunData ReadResults(IExecutionContext executionContext, string filePath, TestRunContext runContext = null)
         {
             // http://windyroad.com.au/dl/Open%20Source/JUnit.xsd
-
+            
             XmlDocument doc = new XmlDocument();
             try
             {
@@ -145,8 +145,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             //create test run data
             var testRunData = new TestRunData(
                 name: runSummary.Name,
-                startedDate: runSummary.TimeStamp.ToString("o"),
-                completedDate: maxCompletedTime.ToString("o"),
+                startedDate: runSummary.TimeStamp != DateTime.MinValue ? runSummary.TimeStamp.ToString("o") : null,
+                completedDate: maxCompletedTime != DateTime.MinValue ? maxCompletedTime.ToString("o") : null,
                 state: TestRunState.InProgress.ToString(),
                 isAutomated: true,
                 buildId: runContext != null ? runContext.BuildId : 0,

--- a/src/Agent.Worker/TestResults/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestRunPublisher.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     // Remove duplicate entries
-                    string[] attachments = (testResults[i + j].AttachmentData.AttachmentsFilePathList != null) ? testResults[i + j].AttachmentData.AttachmentsFilePathList.ToArray() : null;
+                    string[] attachments = (testResults[i + j]?.AttachmentData?.AttachmentsFilePathList != null) ? testResults[i + j].AttachmentData.AttachmentsFilePathList.ToArray() : null;
                     HashSet<string> attachedFiles = GetUniqueTestRunFiles(attachments);
 
                     if (attachedFiles != null)
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     }
 
                     // Upload console log as attachment
-                    string consoleLog = testResults[i + j].AttachmentData.ConsoleLog;
+                    string consoleLog = testResults[i + j]?.AttachmentData?.ConsoleLog;
                     TestAttachmentRequestModel attachmentRequestModel = GetConsoleLogAttachmentRequestModel(consoleLog);
                     if (attachmentRequestModel != null)
                     {
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     }
 
                     // Upload standard error as attachment
-                    string standardError = testResults[i + j].AttachmentData.StandardError;
+                    string standardError = testResults[i + j]?.AttachmentData?.StandardError;
                     TestAttachmentRequestModel stdErrAttachmentRequestModel = GetStandardErrorAttachmentRequestModel(standardError);
                     if (stdErrAttachmentRequestModel != null)
                     {

--- a/src/Agent.Worker/TestResults/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestRunPublisher.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     // Remove duplicate entries
-                    string[] attachments = (testResults[i + j]?.AttachmentData?.AttachmentsFilePathList != null) ? testResults[i + j].AttachmentData.AttachmentsFilePathList.ToArray() : null;
+                    string[] attachments = testResults[i + j]?.AttachmentData?.AttachmentsFilePathList?.ToArray();
                     HashSet<string> attachedFiles = GetUniqueTestRunFiles(attachments);
 
                     if (attachedFiles != null)

--- a/src/Agent.Worker/TestResults/XunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/XunitResultReader.cs
@@ -259,8 +259,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             TestRunData testRunData = new TestRunData(
                 name: runName,
                 buildId: runContext != null ? runContext.BuildId : 0,
-                startedDate: minStartTime.ToString("o"),
-                completedDate: maxCompletedTime.ToString("o"),
+                startedDate: minStartTime != DateTime.MinValue ? minStartTime.ToString("o") : null,
+                completedDate: maxCompletedTime != DateTime.MinValue ? maxCompletedTime.ToString("o") : null,
                 state: TestRunState.InProgress.ToString(),
                 isAutomated: true,
                 buildFlavor: runContext != null ? runContext.Configuration : null,

--- a/src/Test/L0/Worker/TestResults/JunitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/JunitResultReaderTests.cs
@@ -88,6 +88,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             "</testsuite>" +
             "</testsuites>";
 
+        private const string _jUnitWithDefaultDateTime =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<testsuite errors=\"0\" failures=\"1\" hostname=\"mghost\" name=\"com.contoso.billingservice.ConsoleMessageRendererTest\" skipped=\"0\" tests=\"2\" time=\"0.000\" timestamp=\"0001-01-01T00:00:00\">" +
+              "<testcase classname=\"com.contoso.billingservice.ConsoleMessageRendererTest\" name=\"testRenderNullMessage\" time=\"1.001\" />" +
+            "</testsuite>";
+
         private const string c_jUnitMultiSuiteParallelXml =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<testsuites>" +
@@ -193,6 +199,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 
             var time = TimeSpan.FromMilliseconds(_testRunData.Results[0].DurationInMs);
             Assert.Equal(0.001, time.TotalSeconds);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyBehaviorWhenDefaultDateTimePassed()
+        {
+            SetupMocks();
+            // case for duration = maxcompletedtime- minstarttime
+            _junitResultsToBeRead = _jUnitWithDefaultDateTime;
+            ReadResults();
+            Assert.Equal(null, _testRunData.StartDate);
+            Assert.Equal(null, _testRunData.CompleteDate);
         }
 
         [Fact]

--- a/src/Test/L0/Worker/TestResults/XUnitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/XUnitResultReaderTests.cs
@@ -105,6 +105,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         "</assembly>" +
         "</assemblies>";
 
+        private const string _xunitResultsDefaultDateTime = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+        "<assemblies>" +
+        "<assembly name = \"C:\\Users\\somerandomusername\\Source\\Workspaces\\p1\\ClassLibrary2\\ClassLibrary2\\bin\\Debug\\ClassLibrary2.DLL\" environment=\"64-bit .NET 4.0.30319.34014 [collection-per-class, parallel (4 threads)]\" test-framework=\"xUnit.net 2.1.0.3179\" run-date=\"0001-01-01\" run-time=\"00:00:00\" config-file=\"c:\\Users\\vimegh\\Documents\\Visual Studio 2013\\Projects\\ClassLibrary2\\packages\\xunit.runner.console.2.1.0\\tools\\xunit.console.exe.Config\" total=\"5\" passed=\"3\" failed=\"2\" skipped=\"0\" time=\"0.000\" errors=\"0\">" +
+        "<class name=\"MyFirstUnitTests.Class1\">" +
+        "<test name=\"MyFirstUnitTests.Class1.FailingTest\">" +
+        "</test>" +
+        "</class>" +
+        "</assembly>" +
+        "</assemblies>";
+
         private const string _xunitResultsWithDtd = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
         "<!DOCTYPE report PUBLIC '-//JACOCO//DTD Report 1.0//EN' 'report.dtd'>" +
         "<assemblies>" +
@@ -316,6 +326,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             DateTime.TryParse(runData.CompleteDate, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out completeDate);
             Assert.Equal("2016-06-08T07:12:14.4330000Z", completeDate.ToString("o"));
             Assert.Equal((completeDate - startDate).TotalMilliseconds, 5433);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyReadResultsReturnsNullDurationWhenDefaultDateTimePassed()
+        {
+            SetupMocks();
+            //improper date format
+            string xunitResults = _xunitResultsDefaultDateTime;
+            XUnitResultReader reader = new XUnitResultReader();
+
+            _xUnitResultFile = "XUnitResults2.xml";
+            File.WriteAllText(_xUnitResultFile, xunitResults);
+            TestRunData runData = reader.ReadResults(_ec.Object, _xUnitResultFile, new TestRunContext("Owner", "any cpu", "debug", 1, "", "releaseUri", "releaseEnvironmentUri"));
+
+            Assert.Equal(null, runData.StartDate);
+            Assert.Equal(null, runData.CompleteDate);
         }
 
         [Fact]


### PR DESCRIPTION
- Some runners set the start date for run as "0001-01-01..." (DateTime.mintime) but the Test runs API accepts start and complete time in the range of SQLMinTime and SQLMaxTime. So if the time provided in DateTime.MinTime we are sending the starttime as null instead.
- L0 tests remaining to be added