### PR TITLE
Clarify Windows Server 2016 install prereqs

### DIFF
--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -1,6 +1,6 @@
 # ![win](../res/win_med.png) Windows System Prerequisites
 
-## Windows 10 and Beyond (64-bit)
+## Windows 10 and Windows Server 2016 (64-bit)
 
 No known system prerequisites are known at this time.
 


### PR DESCRIPTION
Just makes it clearer since you call out the previous versions below, but 2016 isn't mentioned here