### PR TITLE
Clarify that path filters are supported only for VSTS Git

### DIFF
--- a/docs/preview/yamlgettingstarted-ci.md
+++ b/docs/preview/yamlgettingstarted-ci.md
@@ -45,7 +45,7 @@ trigger:
 ```
 
 
-Note, path filters are only supported for Git repositories in VSTS.
+**Note:** path filters are supported only for VSTS-hosted Git repositories.
 
 ## CI is opt-out
 


### PR DESCRIPTION
I wanted to clarify this caveat since I tripped on this earlier.