### PR TITLE
HostContext.OnEventWritten check for null eventData.Message

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -612,7 +612,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            if (eventData == null && !string.IsNullOrEmpty(eventData.Message))
+            if (eventData == null || string.IsNullOrEmpty(eventData.Message))
             {
                 return;
             }


### PR DESCRIPTION
Under certain scenarios (in our case, having DynaTrace installed), the eventData.Message property is null, which is causing performance issues and unnecessary log output. 

A possible alternative might be to return if the eventData.Message is null instead of logging out a null message.