### PR TITLE
Don't show $3/$4 in the number of retries error message

### DIFF
--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -86,7 +86,7 @@ namespace Agent.Plugins.Repository
 
         protected async Task RunCommandAsync(FormatFlags formatFlags, bool quiet, int retriesOnFailure, params string[] args)
         {
-            for (int attempt = 0; attempt < retriesOnFailure; attempt++)
+            for (int attempt = 0; attempt < retriesOnFailure - 1; attempt++)
             {
                 int exitCode = await RunCommandAsync(formatFlags, quiet, false, args);
 


### PR DESCRIPTION
Solves the displaying of `$` in retry message.
As well as retrying one time too many.

https://github.com/microsoft/azure-pipelines-agent/issues/3577
