### PR TITLE
Add an agent knob that allows to specify driver when creating docker network

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -43,6 +43,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob DockerNetworkCreateDriver = new Knob(
             nameof(DockerNetworkCreateDriver),
             "Allow to specify which driver will be used when creating docker network",
+            new RuntimeKnobSource("agent.DockerNetworkCreateDriver"),
             new EnvironmentKnobSource("AZP_AGENT_DOCKER_NETWORK_CREATE_DRIVER"),
             new BuiltInDefaultKnobSource(string.Empty));
 

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             var usingWindowsContainers = context.Containers.Where(x => x.ExecutionOS != PlatformUtil.OS.Windows).Count() == 0;
             var networkDrivers = await ExecuteDockerCommandAsync(context, "info", "-f \"{{range .Plugins.Network}}{{println .}}{{end}}\"");
             var valueMTU = AgentKnobs.MTUValueForContainerJobs.GetValue(_knobContext).AsString();
-            var driver = AgentKnobs.DockerNetworkCreateDriver.GetValue(_knobContext).AsString();
+            var driver = AgentKnobs.DockerNetworkCreateDriver.GetValue(context).AsString();
             string optionMTU = "";
 
             if (!String.IsNullOrEmpty(valueMTU))


### PR DESCRIPTION
**Description:** this pull request provides an implementation of new logic that allows to specify driver when creating docker network via the `AZP_AGENT_DOCKER_NETWORK_CREATE_DRIVER` environment variable (agent knob).

**ChangeLog:**
* `src/Agent.Sdk/Knob/AgentKnobs.cs` — new agent konb is added
* `src/Agent.Worker/Container/DockerCommandManager.cs` — using of specified driver is implemented

Tested these changes end-to-end manually in the following cases:
* If the `AZP_AGENT_DOCKER_NETWORK_CREATE_DRIVER` agent knob is NOT specified, the agent behavior remains the same.
* If this agent knob is specified and such driver actually exists, it will be used.
* If this agent knob is specified but such driver does not exist, a default driver will be used. Warning about this can be found in the agent diagnostic logs and in the pipeline run logs.

[Related issue](https://github.com/microsoft/azure-pipelines-agent/issues/3566)