### PR TITLE
OaepSHA1 -> OaepSHA256

### DIFF
--- a/src/Agent.Listener/Configuration/IRSAKeyManager.cs
+++ b/src/Agent.Listener/Configuration/IRSAKeyManager.cs
@@ -35,9 +35,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         void DeleteKey();
 
         /// <summary>
-        /// Gets the <c>RSACryptoServiceProvider</c> instance currently stored by the key manager. 
+        /// Gets the <c>RSA</c> instance currently stored by the key manager. 
         /// </summary>
-        /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the agent</returns>
+        /// <returns>An <c>RSA</c> implementation representing the key for the agent</returns>
         /// <exception cref="CryptographicException">No key exists in the store</exception>
         RSA GetKey();
     }

--- a/src/Agent.Listener/Configuration/RSAFileKeyManager.cs
+++ b/src/Agent.Listener/Configuration/RSAFileKeyManager.cs
@@ -16,12 +16,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
         public RSA CreateKey(bool enableAgentKeyStoreInNamedContainer, bool useCng)
         {
-            RSACryptoServiceProvider rsa = null;
+            RSA rsa = null;
             if (!File.Exists(_keyFile))
             {
                 Trace.Info("Creating new RSA key using 2048-bit key length");
 
-                rsa = new RSACryptoServiceProvider(2048);
+                rsa = RSA.Create(2048);
 
                 // Now write the parameters to disk
                 IOUtil.SaveObject(new RSAParametersSerializable("", false, rsa.ExportParameters(true)), _keyFile);
@@ -53,9 +53,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             else
             {
                 Trace.Info("Found existing RSA key parameters file {0}", _keyFile);
-
-                rsa = new RSACryptoServiceProvider();
-                rsa.ImportParameters(IOUtil.LoadObject<RSAParametersSerializable>(_keyFile).RSAParameters);
+                rsa = RSA.Create(IOUtil.LoadObject<RSAParametersSerializable>(_keyFile).RSAParameters);
             }
 
             return rsa;
@@ -80,8 +78,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             Trace.Info("Loading RSA key parameters from file {0}", _keyFile);
 
             var parameters = IOUtil.LoadObject<RSAParametersSerializable>(_keyFile).RSAParameters;
-            var rsa = new RSACryptoServiceProvider();
-            rsa.ImportParameters(parameters);
+            var rsa = RSA.Create(parameters);
             return rsa;
         }
 

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
         private int _expectedPoolId = 1;
         private int _expectedDeploymentMachineId = 81;
         private int _expectedEnvironmentVMResourceId = 71;
-        private RSACryptoServiceProvider rsa = null;
+        private RSA rsa = null;
         private AgentSettings _configMgrAgentSettings = new AgentSettings();
 
         public ConfigurationManagerL0()
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
             _agentServer.Setup(x => x.AddAgentAsync(It.IsAny<int>(), It.IsAny<TaskAgent>())).Returns(Task.FromResult(expectedAgent));
             _agentServer.Setup(x => x.UpdateAgentAsync(It.IsAny<int>(), It.IsAny<TaskAgent>())).Returns(Task.FromResult(expectedAgent));
 
-            rsa = new RSACryptoServiceProvider(2048);
+            rsa = RSA.Create(2048);
 
             _rsaKeyManager.Setup(x => x.CreateKey(It.IsAny<bool>(), It.IsAny<bool>())).Returns(rsa);
 

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
         private Mock<ICapabilitiesManager> _capabilitiesManager;
         private Mock<IFeatureFlagProvider> _featureFlagProvider;
         private Mock<IRSAKeyManager> _rsaKeyManager;
-        private readonly RSACryptoServiceProvider rsa;
+        private readonly RSA rsa;
 
         public MessageListenerL0()
         {
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
             _featureFlagProvider.Setup(x => x.GetFeatureFlagAsync(It.IsAny<IHostContext>(), It.IsAny<string>(), It.IsAny<ITraceWriter>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new FeatureAvailability.FeatureFlag("", "", "", "Off", "Off")));
             _featureFlagProvider.Setup(x => x.GetFeatureFlagWithCred(It.IsAny<IHostContext>(), It.IsAny<string>(), It.IsAny<ITraceWriter>(), It.IsAny<AgentSettings>(), It.IsAny<VssCredentials>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new FeatureAvailability.FeatureFlag("", "", "", "Off", "Off")));
 
-            rsa = new RSACryptoServiceProvider(2048);
+            rsa = RSA.Create(2048);
             _rsaKeyManager.Setup(x => x.CreateKey(It.IsAny<bool>(), It.IsAny<bool>())).Returns(rsa);
         }
 


### PR DESCRIPTION
This has been flagged by CodeQL for some time.

The backend side change adding OaepSHA256 has rolled out everywhere, the Agent side now needs to be updated to request it.

I tested the OaepSHA256 code path locally, with Windows and macOS self-hosted Agent.

Notes:
- RSACryptoServiceProvider is a legacy implementation, that only supports OaepSHA1, see [RSACryptoServiceProvider.Decrypt](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.rsacryptoserviceprovider.decrypt?view=net-8.0) docs.
- However, `RSA.Create()` does not support `KeyContainerName`, I had to work around that.
- Actions Runner switched to OaepSHA256 almost five years ago.