### PR TITLE
Avoid constructing NetworkCredential objects on macOS machines

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -779,5 +779,11 @@ namespace Agent.Sdk.Knob
             "If true, agent will use sparse checkout in checkout task.",
             new RuntimeKnobSource("AGENT_USE_SPARSE_CHECKOUT_IN_CHECKOUT_TASK"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob AvoidNetCredentialObjectsOnMac = new Knob(
+            nameof(AvoidNetCredentialObjectsOnMac),
+            "Eliminates construction of NetwokCredential objects on macOS, which internally suffer from malloc-related crashes",
+            new EnvironmentKnobSource("AVOID_NET_CREDENTIAL_OBJECTS_ON_MAC"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/LinuxAgentCredentialStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/LinuxAgentCredentialStore.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             _symmetricKey = keyBuilder.ToArray();
         }
 
-        public NetworkCredential Write(string target, string username, string password)
+        public void Write(string target, string username, string password)
         {
             Trace.Entering();
             ArgUtil.NotNullOrEmpty(target, nameof(target));
@@ -79,7 +79,6 @@ namespace Microsoft.VisualStudio.Services.Agent
             Credential cred = new Credential(username, Encrypt(password));
             _credStore[target] = cred;
             SyncCredentialStoreFile();
-            return new NetworkCredential(username, password);
         }
 
         public NetworkCredential Read(string target)
@@ -98,6 +97,13 @@ namespace Microsoft.VisualStudio.Services.Agent
             }
 
             throw new KeyNotFoundException(target);
+        }
+
+        public (string UserName, string Password) Read2(string target)
+        {
+            // NetworkCredential objects cause crashes only on macOS => we can invoke the original implemantation here
+            var ret = Read(target);
+            return (ret.UserName, ret.Password);
         }
 
         public void Delete(string target)

--- a/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/MacOSAgentCredentialStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/MacOSAgentCredentialStore.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             }
         }
 
-        public NetworkCredential Write(string target, string username, string password)
+        public void Write(string target, string username, string password)
         {
             Trace.Entering();
             ArgUtil.NotNullOrEmpty(target, nameof(target));
@@ -161,8 +161,6 @@ namespace Microsoft.VisualStudio.Services.Agent
                         throw new InvalidOperationException($"'security add-generic-password' failed with exit code {exitCode}.");
                     }
                 }
-
-                return new NetworkCredential(username, password);
             }
             finally
             {
@@ -171,6 +169,17 @@ namespace Microsoft.VisualStudio.Services.Agent
         }
 
         public NetworkCredential Read(string target)
+        {
+            var cred = ReadCredentialFromKeychain(target);
+            return new NetworkCredential(cred.UserName, cred.Password);
+        }
+
+        public (string UserName, string Password) Read2(string target)
+        {
+            return ReadCredentialFromKeychain(target);
+        }
+
+        public (string UserName, string Password) ReadCredentialFromKeychain(string target)
         {
             Trace.Entering();
             ArgUtil.NotNullOrEmpty(target, nameof(target));
@@ -223,7 +232,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                             Trace.Info($"Successfully find-generic-password for {target} (VSTSAGENT)");
                             username = Encoding.UTF8.GetString(Convert.FromBase64String(secrets[0]));
                             password = Encoding.UTF8.GetString(Convert.FromBase64String(secrets[1]));
-                            return new NetworkCredential(username, password);
+                            return (username, password);
                         }
                         else
                         {

--- a/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/NoOpAgentCredentialStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/NoOpAgentCredentialStore.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             base.Initialize(hostContext);
         }
 
-        public NetworkCredential Write(string target, string username, string password)
+        public void Write(string target, string username, string password)
         {
             Trace.Entering();
             ArgUtil.NotNullOrEmpty(target, nameof(target));
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.Services.Agent
             ArgUtil.NotNullOrEmpty(password, nameof(password));
 
             Trace.Info($"Attempt to store credential for '{target}' to cred store.");
-            return new NetworkCredential(username, password);
         }
 
         public NetworkCredential Read(string target)
@@ -32,6 +31,12 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             Trace.Info($"Attempt to read credential for '{target}' from cred store.");
             throw new KeyNotFoundException(target);
+        }
+
+        public (string UserName, string Password) Read2(string target)
+        {
+            var ret = Read(target);
+            return (ret.UserName, ret.Password);
         }
 
         public void Delete(string target)

--- a/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/WindowsAgentCredentialStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/AgentCredentialStore/WindowsAgentCredentialStore.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             }
         }
 
-        public NetworkCredential Write(string target, string username, string password)
+        public void Write(string target, string username, string password)
         {
             Trace.Entering();
             ArgUtil.NotNullOrEmpty(target, nameof(target));
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             SyncCredentialStoreFile();
 
             // save to Windows Credential Store
-            return WriteInternal(target, username, password);
+            WriteInternal(target, username, password);
         }
 
         public NetworkCredential Read(string target)
@@ -138,6 +138,13 @@ namespace Microsoft.VisualStudio.Services.Agent
                     CredFree(credPtr);
                 }
             }
+        }
+
+        public (string UserName, string Password) Read2(string target)
+        {
+            // NetworkCredential objects cause crashes only on macOS => we can invoke the original implemantation here
+            var ret = Read(target);
+            return (ret.UserName, ret.Password);
         }
 
         public void Delete(string target)

--- a/src/Microsoft.VisualStudio.Services.Agent/IAgentCredentialStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/IAgentCredentialStore.cs
@@ -14,10 +14,14 @@ namespace Microsoft.VisualStudio.Services.Agent
       )]
     public interface IAgentCredentialStore : IAgentService
     {
-        NetworkCredential Write(string target, string username, string password);
+        void Write(string target, string username, string password);
 
         // throw exception when target not found from cred store
         NetworkCredential Read(string target);
+
+
+        // variant that does not return NetworkCredential class, which suffers from OS-level crashes on macOS
+        (string UserName, string Password) Read2(string target);
 
         // throw exception when target not found from cred store
         void Delete(string target);

--- a/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
@@ -188,9 +188,22 @@ namespace Microsoft.VisualStudio.Services.Agent
                     if (!string.IsNullOrEmpty(lookupKey))
                     {
                         var credStore = HostContext.GetService<IAgentCredentialStore>();
-                        var proxyCred = credStore.Read($"VSTS_AGENT_PROXY_{lookupKey}");
-                        ProxyUsername = proxyCred.UserName;
-                        ProxyPassword = proxyCred.Password;
+                        var avoidNetCredentialFF = AgentKnobs.AvoidNetCredentialObjectsOnMac.GetValue(HostContext).AsBoolean();
+                        var target = $"VSTS_AGENT_PROXY_{lookupKey}";
+
+                        if (avoidNetCredentialFF)
+                        {
+                            var proxyCred = credStore.Read2(target);
+                            ProxyUsername = proxyCred.UserName;
+                            ProxyPassword = proxyCred.Password;
+                        }
+                        else
+                        {
+                            NetworkCredential proxyCred = credStore.Read(target);
+                            ProxyUsername = proxyCred.UserName;
+                            ProxyPassword = proxyCred.Password;
+                        }
+
                     }
                 }
 


### PR DESCRIPTION
Customers who use macOS agents behind an HTTP proxy suffer from malloc-related crashes described in https://github.com/dotnet/runtime/issues/97966. The crash does not happen immediately, but after a few jobs are executed by the Agent.

When an HTTP proxy is configured, the Agent code creates NetworkCredential objects to pass basic auth creds.
From stack trace posted in the above issue, it sounds like the crash happens when internal .NET networking objects are being released/disposed. That could explain why customers are able to execute a few jobs ok - the crash happens when GC kicks in.