### PR TITLE
Fixing the replace prompt appearing everytime

### DIFF
--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             while (true)
             {
                 agentSettings.AgentName = command.GetAgentName();
-                Trace.Info($"Agent registration attempt - Name: '{agentSettings.AgentName}', Pool: '{agentSettings.PoolName}' (ID: {agentSettings.PoolId}), ReplaceMode: {command.GetReplace()}");
+                Trace.Info($"Agent registration attempt - Name: '{agentSettings.AgentName}', Pool: '{agentSettings.PoolName}' (ID: {agentSettings.PoolId})");
 
                 // Get the system capabilities.
                 // TODO: Hook up to ctrl+c cancellation token.


### PR DESCRIPTION
### **Context**
This PR addresses an issue where the agent configuration process was prompting users to replace an agent before checking if an agent with the same name actually exists in the pool. The problem was causing the replacement prompt to appear prematurely, even when no existing agent was found, which created a confusing user experience and didn't match the expected behavior from previous agent versions.

[AB#2324576](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2324576)

---

### **Description**
Fixed the agent configuration flow to only prompt for agent replacement when an existing agent with the same name is actually found in the pool. The issue was caused by a premature call to command.GetReplace() in a trace logging statement that triggered the replacement prompt before the agent existence check was performed.

Changes made:
- Removed command.GetReplace() call from the trace logging statement that was executing before the agent existence check

---

### **Risk Assessment** (Low / Medium / High)  
Low Risk - This is a targeted fix to the configuration flow logic 

---

### **Unit Tests Added or Updated** (Yes / No)  
No new unit tests were added as this is a behavioral fix in the interactive configuration flow. The existing configuration tests should cover the core functionality.

---

### **Additional Testing Performed**
Manual testing of agent configuration scenarios:

- New agent registration (no existing agent) - should not prompt for replacement
- Existing agent replacement - should prompt for replacement only after detecting existing agent

--- 

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
Root Cause: command.GetReplace() was being called prematurely in trace logging before checking if an agent exists
Solution: Moved the replacement logic to only execute when an existing agent is actually found

---

### **Documentation Changes Required** (Yes/No)
No

---
### **Logging Added/Updated** (Yes/No)
Updated trace logging to remove premature GetReplace() call

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
