### PR TITLE
Remove conditional check on docker network plugin existence.

### DIFF
--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -282,7 +282,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
                 options += $" {additionalNetworCreateOptions}";
             }
 
-            return await ExecuteDockerCommandAsync(context, "network", options, context.CancellationToken);
+            // When originally introduced in #3751 the network driver check did automated fallback to "no network driver."
+            // In order to maintain that automated fallback behavior but not exclude custom network plugins we now attempt
+            // to create the network and, upon failure, retry with the network-driver-less invocation.
+            exitCode = await ExecuteDockerCommandAsync(context, "network", options, context.CancellationToken);
+            if (exitCode != 0)
+            {
+                string warningMessage = $"Specified '{driver}' driver not found! Retrying with unset driver.";
+                Trace.Warning(warningMessage);
+                context.Warning(warningMessage);
+                string networkDriverlessOptions = options.Replace($" --driver {driver}", "");
+                return await ExecuteDockerCommandAsync(context, "network", networkDriverlessOptions, context.CancellationToken)
+            }
+
+            return exitCode;
         }
 
         public async Task<int> DockerNetworkRemove(IExecutionContext context, string network)


### PR DESCRIPTION
This PR removes the check for existence of a network driver prior to attempting use.

> Plugins are not activated automatically at Docker daemon startup. Rather, they are activated only lazily, or on-demand, when they are needed. https://docs.docker.com/engine/extend/plugin_api/#plugin-activation

As a consequence, if you write a custom network driver and attempt to use it for your Azure Pipelines Agent, the plugin has not been registered at that time.

You instead get the warning message and shunted back to the default.

This code was added in #3751 and this would be the first update since landing it.

***

Without this change, attempting to use a custom network plugin fails:
<img width="1015" height="297" alt="" src="https://github.com/user-attachments/assets/9cba4bfe-1857-4c86-b9ca-f18b740a823f" />

```sh
/usr/bin/docker info -f "{{range .Plugins.Network}}{{println .}}{{end}}"
bridge
host
ipvlan
macvlan
null
overlay
##[warning]Specified 'wireguard' driver not found!
/usr/bin/docker network create --label 8578ca vsts_network_174a1ae0516444449e9a26cc428af7c8
be79b766bbd1cfcd57483a66867f30be54191a7a784847d5d83c07a4a224938f
```