### PR TITLE
Replacing 'm' with 'M' in the path for Create PRs step in vsts release pipeline

### DIFF
--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -209,7 +209,7 @@ async function main() {
             `Update agent publish script to version ${agentVersion}`,
             [
                 path.join(
-                    'tfs', `m${sprint}`, 'PipelinesAgentRelease', agentVersion, 'Publish.ps1'
+                    'tfs', `M${sprint}`, 'PipelinesAgentRelease', agentVersion, 'Publish.ps1'
                 )
             ],
             dryrun


### PR DESCRIPTION
### **Context**
Replacing 'm' with 'M' in the path for the create PRs step in the vsts release pipeline.

---

### **Description**
Replacing 'm' with 'M' in the path for creating PRs in the vsts release pipeline.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No

--- 

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
This is a temporary fix to solve the error caused due to mismatch in uppercase and lowercase in path for Create PRs step in vsts release pipeline.

---

### **Documentation Changes Required** (Yes/No)
No

---
### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
