### PR TITLE
Update the location of .autoManagedVhd marker file

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -618,7 +618,7 @@ namespace Agent.Plugins.Repository
                     }
                 }
 
-                string agentWorkFolder = Environment.GetEnvironmentVariable("AGENT_WORKFOLDER");
+                string agentWorkFolder = executionContext.Variables.GetValueOrDefault("agent.workfolder")?.Value;
                 if (!string.IsNullOrEmpty(agentWorkFolder)
                     && File.Exists(Path.Combine(agentWorkFolder, ".autoManagedVhd"))
                     && !AgentKnobs.DisableAutoManagedVhdShallowOverride.GetValue(executionContext).AsBoolean())


### PR DESCRIPTION
### **Context**
Azure DevOps is one of the major AutoManagedVHD customers, and one of their pipelines performs a “changed files” check inside the repository.
Previously, the .autoManagedVhd marker file was created inside the sources directory, which caused that step to incorrectly detect the marker as a modified file. This issue could easily impact other customers with similar checks.

To avoid interfering with repository-level file-change detection, it is safer and more correct to place the marker file in the parent directory of the sources directory. This still allows the agent to reliably detect that the existing working directory originates from an AutoManagedVHD.

### **Description**
This PR updates the detection logic so the .autoManagedVhd marker file is looked up in the parent directory of the repository instead of inside it.

### **Risk Assessment** (Low / Medium / High)  
The change only applies when a .autoManagedVhd file is present and does not affect normal checkout scenarios.

### **Unit Tests Added or Updated** (Yes / No)  
No