### PR TITLE
Changing the Pool from 1ES-Shared-Hosted-Pool_Windows-Server-2022 to 1ES-ABTT-Shared-Pool

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -217,6 +217,7 @@ extends:
             name: 1ES-ABTT-Shared-Pool
             image: abtt-windows-2025
             os: windows
+            demands: AzurePS
           variables:
             IsTestRun: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ]
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]


### PR DESCRIPTION
### **Context**
As 1ES shared pools are deprecated and also the pool: **1ES-Shared-Hosted-Pool_Windows-Server-2022** has deprecated artifacts we have changed the pool to **1ES-ABTT-Shared-Pool**

Please refer: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/orgs/1es

Related work-item: [AB#2353184](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2353184)

---

### **Description**
The pool **1ES-Shared-Hosted-Pool_Windows-Server-2022** is deprecated and it was also using deprecated artifacts. Due to this our Agent release pipeline: https://dev.azure.com/mseng/AzureDevOps/_build?definitionId=5845&_a=summary is throwing error which raised S360 alerts.

Error message:
<img width="1135" height="157" alt="image" src="https://github.com/user-attachments/assets/eb04b45d-fa35-4a8f-b76c-2da45dcd340f" />

So to resolve this S360 alerts we have replaced the pool with **1ES-ABTT-Shared-Pool**. The image **abtt-windows-2025** in this pool uses the new artifacts.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
NA

--- 

### **Change Behind Feature Flag** (Yes / No)
No. Because this is not a functionality change.

---

### **Tech Design / Approach**
We were using deprecated images which caused S360 alerts so we have updated to pool which has images with latest artifacts.

---

### **Documentation Changes Required** (Yes/No)
No

---
### **Logging Added/Updated** (Yes/No)
NA

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA