### PR TITLE
Clean unused npm/lib from Node.js extracts to resolve CG vulnerabilities

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -126,6 +126,15 @@ function acquireExternalTool() {
                 echo "Testing tar gz"
                 tar xzf "$download_target" -C "$extract_dir" > /dev/null || checkRC 'tar'
             fi
+
+            if [[ "$download_basename" == node-v*.tar.gz ]]; then
+                echo "Cleaning Node.js distribution extract - removing unused npm/lib"
+                find "$extract_dir" -path "*/lib/node_modules" -type d -exec rm -rf {} + 2>/dev/null || true
+                find "$extract_dir" \( -name "npm" -o -name "npx" -o -name "corepack" \) -not -type d -delete 2>/dev/null || true
+                find "$extract_dir" -path "*/include" -type d -exec rm -rf {} + 2>/dev/null || true
+                find "$extract_dir" -path "*/share" -type d -exec rm -rf {} + 2>/dev/null || true
+                find "$extract_dir" \( -name "CHANGELOG.md" -o -name "README.md" \) -delete 2>/dev/null || true
+            fi
         fi
     else
         # Extract to layout.


### PR DESCRIPTION
### **Context**
The agent only uses the 'node' binary from Node.js distributions, but the downloaded tarballs include npm and its transitive dependencies (minimatch, tar, glob, form-data, etc.).

This change removes lib/node_modules, npm, npx, corepack, include, and share from the precache .extract/ directories after extraction. The original .tar.gz files are preserved for the layout step, which has its own cleanup.

[AB#2359588](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359588)
[AB#2359589](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359589)
[AB#2359590](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359590)
[AB#2359591](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359591)
[AB#2359592](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359592)
[AB#2359593](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359593)
[AB#2359594](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359594)
[AB#2359595](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359595)
[AB#2359596](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359596)
[AB#2359597](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359597)
[AB#2359598](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359598)
[AB#2359599](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359599)
[AB#2359600](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359600)
[AB#2359601](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359601)
[AB#2359602](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359602)
[AB#2359603](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359603)
[AB#2359604](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359604)
[AB#2359605](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359605)
[AB#2359607](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359607)
[AB#2359608](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359608)
[AB#2359609](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359609)
[AB#2359610](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359610)
[AB#2359611](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359611)
[AB#2359612](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359612)
[AB#2359614](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359614)
[AB#2362046](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362046)
[AB#2362047](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362047)
[AB#2362048](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362048)
[AB#2362049](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362049)
[AB#2362050](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362050)
[AB#2362051](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362051)
[AB#2362054](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362054)
[AB#2362055](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362055)
[AB#2362056](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362056)
[AB#2362057](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362057)
[AB#2362058](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362058)
[AB#2362059](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362059)
[AB#2364145](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2364145)
[AB#2364251](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2364251)
[AB#2364252](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2364252)
[AB#2364253](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2364253)
[AB#2364265](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2364265)---

### **Description**
The agent only uses the 'node' binary from Node.js distributions, but the downloaded tarballs include npm and its transitive dependencies (minimatch, tar, glob, form-data, etc.).

This change removes lib/node_modules, npm, npx, corepack, include, and share from the precache .extract/ directories after extraction. The original .tar.gz files are preserved for the layout step, which has its own cleanup.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
NA

---

### **Additional Testing Performed**
Manually running test cases

--- 

### **Change Behind Feature Flag** (Yes / No)
NA

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
NA

---
### **Logging Added/Updated** (Yes/No)
NA

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
