### PR TITLE
Trimming BuildTag before adding to server

### DIFF
--- a/src/Agent.Worker/Build/BuildCommandExtension.cs
+++ b/src/Agent.Worker/Build/BuildCommandExtension.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             ArgUtil.NotNull(context.Endpoints, nameof(context.Endpoints));
             ArgUtil.NotNull(command, nameof(command));
 
-            string data = command.Data;
+            string data = command.Data?.Trim();
 
             Guid projectId = context.Variables.System_TeamProjectId ?? Guid.Empty;
             ArgUtil.NotEmpty(projectId, nameof(projectId));


### PR DESCRIPTION
### **Context**
Build pipelines failed with **BuildTagAddFailed** errors when adding tags , impacting multiple pipelines and blocking development workflows. The agent's tag comparison logic was sensitive to whitespace differences between the tag sent and the tag returned by the server, causing false-positive failures. This PR adds whitespace trimming on the agent side.

> 📌 [AB#2342273](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2342273)

---
### **Description**
Trim leading and trailing whitespace from build tag data in `BuildAddBuildTagCommand.Execute()` before processing. Changed `command.Data` to `command.Data?.Trim() `when handling `##vso[build.addbuildtag]` logging commands.

---

### **Risk Assessment** - Low 
Single-line change adding .Trim() to tag value.
Build tags with intentional leading/trailing whitespace are not a valid use case.
Backward compatible — tags without whitespace are unaffected.

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

- Deployed updated agent to self-hosted agent.
- Ran pipeline with `##vso[build.addbuildtag]` commands using tags with leading spaces, trailing spaces, both, and none.
- Without fix: Tags with trailing/both-side whitespace caused Build tag was not added successfully errors.
- With fix: All tags added successfully and verified clean via REST API.

--- 

### **Change Behind Feature Flag** (Yes / No)
 No

---

### **Documentation Changes Required** (Yes/No)
 No

---
### **Logging Added/Updated** 
No, Existing debug log will now show the trimmed value, which is the desired behavior.

--- 

### **Telemetry Added/Updated** 
No

---

### **Rollback Scenario and Process** (Yes/No)
Revert the single-line change

---
