### PR TITLE
Add fetchFilter option to the git submodules

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -447,7 +447,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        public async Task<int> GitSubmoduleUpdate(AgentTaskPluginExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleUpdate(AgentTaskPluginExecutionContext context, string repositoryPath, int fetchDepth, IEnumerable<string> filters, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Update the registered git submodules.");
             string options = "update --init --force";
@@ -455,6 +455,11 @@ namespace Agent.Plugins.Repository
             {
                 options = options + $" --depth={fetchDepth}";
             }
+            if (filters != null)
+            {
+                options += " " + string.Join(" ", filters.Select(f => "--filter=" + f));
+            }
+
             if (recursive)
             {
                 options = options + " --recursive";

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -455,7 +455,7 @@ namespace Agent.Plugins.Repository
             {
                 options = options + $" --depth={fetchDepth}";
             }
-            if (filters != null)
+            if (AgentKnobs.UseFetchFilterInGitSubmoduleUpdate.GetValue(context).AsBoolean() && filters != null)
             {
                 options += " " + string.Join(" ", filters.Select(f => "--filter=" + f));
             }

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -1200,7 +1200,7 @@ namespace Agent.Plugins.Repository
                     }
                 }
 
-                int exitCode_submoduleUpdate = await gitCommandManager.GitSubmoduleUpdate(executionContext, targetPath, fetchDepth, string.Join(" ", additionalSubmoduleUpdateArgs), checkoutNestedSubmodules, cancellationToken);
+                int exitCode_submoduleUpdate = await gitCommandManager.GitSubmoduleUpdate(executionContext, targetPath, fetchDepth, additionalFetchFilterOptions, string.Join(" ", additionalSubmoduleUpdateArgs), checkoutNestedSubmodules, cancellationToken);
                 if (exitCode_submoduleUpdate != 0)
                 {
                     throw new InvalidOperationException($"Git submodule update failed with exit code: {exitCode_submoduleUpdate}");

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -814,7 +814,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob UseFetchFilterInGitSubmoduleUpdate = new Knob(
             nameof(UseFetchFilterInGitSubmoduleUpdate),
             "If true, agent will pass fetch filter options in checkout task to git submodule update.",
-            new PipelineFeatureSource("DistributedTask.Agent.UseFetchFilterInGitSubmoduleUpdate"),
+            new PipelineFeatureSource("UseFetchFilterInGitSubmoduleUpdate"),
             new RuntimeKnobSource("AGENT_USE_FETCH_FILTER_IN_GIT_SUBMODULE_UPDATE"),
             new EnvironmentKnobSource("AGENT_USE_FETCH_FILTER_IN_GIT_SUBMODULE_UPDATE"),
             new BuiltInDefaultKnobSource("false"));

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -811,6 +811,14 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_USE_FETCH_FILTER_IN_CHECKOUT_TASK"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob UseFetchFilterInGitSubmoduleUpdate = new Knob(
+            nameof(UseFetchFilterInGitSubmoduleUpdate),
+            "If true, agent will pass fetch filter options in checkout task to git submodule update.",
+            new PipelineFeatureSource("DistributedTask.Agent.UseFetchFilterInGitSubmoduleUpdate"),
+            new RuntimeKnobSource("AGENT_USE_FETCH_FILTER_IN_GIT_SUBMODULE_UPDATE"),
+            new EnvironmentKnobSource("AGENT_USE_FETCH_FILTER_IN_GIT_SUBMODULE_UPDATE"),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob StoreAgentKeyInCSPContainer = new Knob(
             nameof(StoreAgentKeyInCSPContainer),
             "Store agent key in named container (Windows).",


### PR DESCRIPTION
### **Context**
_Pass the `fetchFilter` option to `git submodule update` along with the root repo fetch, fixing partial clone support for submodules._  
Bug - https://github.com/microsoft/azure-pipelines-agent/issues/5452
📌 [AB#2349741](https://mseng.visualstudio.com/AzureDevOps/_sprints/taskboard/Pipeline%20Agent%20and%20Tasks%20-%20IDC/AzureDevOps/OneVS/Sprint%20272?workitem=2349741)

---

### **Description**
 Previously, the `fetchFilter` YAML input (e.g., blob:none or tree:0) was only applied to the root repository's `git fetch` command. When submodules were enabled (submodules: true or submodules: recursive), the
  `git submodule update` command ran without any `--filter` flag, causing submodules to be fully cloned even when partial clone was requested.

  Changes made:

   1. GitCliManager.cs — GitSubmoduleUpdate() method:
    - Added a new IEnumerable<string> filters parameter to the method signature
    - When filters are provided and the `UseFetchFilterInGitSubmoduleUpdate` knob is enabled, appends `--filter=`<value> flags to the git submodule update command
    - The resulting command becomes: git submodule update --init --force [--depth=N] [--filter=blob:none] [--recursive]
   2. GitSourceProvider.cs — GetSourceAsync() call site:
    - Passes the already-parsed additionalFetchFilterOptions (from the YAML fetchFilter input) to GitSubmoduleUpdate(), reusing the same filter parsing logic that GitFetch() already uses
  3. AgentKnobs.cs — New feature flag:
    - Added UseFetchFilterInGitSubmoduleUpdate knob with three sources:
     - Pipeline feature flag: DistributedTask.Agent.UseFetchFilterInGitSubmoduleUpdate
     - Runtime & Environment variable: AGENT_USE_FETCH_FILTER_IN_GIT_SUBMODULE_UPDATE
     - Default: false (disabled) — no behavioral change unless explicitly opted in


  **Before**: `git submodule update --init --force --recursive` (full clone of submodules) 
**After**: `git submodule update --init --force --filter=blob:none --recursive` (partial clone of submodules)

---

### **Risk Assessment** ( Low )  
_This change is behind a new, dedicated feature flag (UseFetchFilterInGitSubmoduleUpdate, default: false). With the flag disabled, the behavior is identical to today — filters are passed into the method but the knob check prevents them from being applied. Risk is limited to users who explicitly enable the flag. This allows controlled rollout via the DistributedTask.Agent.UseFetchFilterInGitSubmoduleUpdate pipeline feature flag._

---

### **Unit Tests Added or Updated** ( No)  
_Indicate whether unit tests were added or modified to reflect the changes._

---

### **Additional Testing Performed**
_Tested the behavior using self-hosted agents with fetchFilter: blob:none and submodules: recursive. Verified that the --filter=blob:none flag now appears in the git submodule update command when the UseFetchFilterInGitSubmoduleUpdate  knob is true.(either using the pipeline variable or by enables the FF ON using the lightrail)_
Before  -
<img width="1276" height="117" alt="image" src="https://github.com/user-attachments/assets/8b83819c-2d8f-4e36-aae0-81db08c2c90c" />

After - 
<img width="1409" height="125" alt="image" src="https://github.com/user-attachments/assets/d4dcd7f5-7043-42c6-b3c8-af4f6d7617ee" />

--- 

### **Change Behind Feature Flag** (Yes)
New knob `UseFetchFilterInGitSubmoduleUpdate` added with:

 - Pipeline feature: DistributedTask.Agent.UseFetchFilterInGitSubmoduleUpdate
 - Runtime & Environment variable: AGENT_USE_FETCH_FILTER_IN_GIT_SUBMODULE_UPDATE
 - Default: false

The filter is only applied to git submodule update when this knob is explicitly enabled, ensuring zero impact on existing users until the flag is turned on.

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Documentation Changes Required** (Yes/No)
_Indicate whether related documentation needs to be updated._
- User guides, API specs, system diagrams, or runbooks are updated. 

---
### **Logging Added/Updated** (No)
- Appropriate log statements are added with meaningful messages. 
- Logging does not expose sensitive data. 
- Log levels are used correctly (e.g., info, warn, error). 

--- 

### **Telemetry Added/Updated** (No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes)
- Rollback plan is documented. 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.
