### PR TITLE
Disable Node 6 download in JobExtensionL0 tests

### DIFF
--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -68,6 +68,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         private Mock<IAsyncCommandContext> _asyncCommandContext;
         private TestHostContext CreateTestContext(CancellationTokenSource _tokenSource, [CallerMemberName] String testName = "")
         {
+            // Prevent L0 tests from making a real HTTP download of Node 6
+            Environment.SetEnvironmentVariable("AGENT_DISABLE_NODE6_TASKS", "true");
+
             var hc = new TestHostContext(this, testName);
             _jobEc = new Agent.Worker.ExecutionContext();
             _taskManager = new Mock<ITaskManager>();
@@ -285,6 +288,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
         private TestHostContext CreateMSITestContext(CancellationTokenSource _tokenSource, [CallerMemberName] String testName = "")
         {
+            // Prevent L0 tests from making a real HTTP download of Node 6
+            Environment.SetEnvironmentVariable("AGENT_DISABLE_NODE6_TASKS", "true");
+
             TestHostContext hc = new TestHostContext(this, testName);
             _jobEc = new Agent.Worker.ExecutionContext();
             _taskManager = new Mock<ITaskManager>();


### PR DESCRIPTION



### **Context**
[AB#2359614](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2359614)

This will also fix the CG bug detected in tests folder in Node6. 

---

### **Description**

JobExtensionL0 tests call testExtension.InitializeJob() which invokes the base JobExtension.InitializeJob(). This triggers NodeJsUtil.DownloadNodeRunnerAsync() to make a real HTTP download of Node 6 from blob storage into the test output externals directory (src/Test/bin/Debug/net8.0/externals/node/). This is an unwanted side effect that slows down tests and creates unnecessary files.

Set AGENT_DISABLE_NODE6_TASKS=true in both CreateTestContext and CreateMSITestContext to skip the Node 6 download via the existing DisableNode6Tasks knob.


---

### **Risk Assessment** (Low / Medium / High)  
LOW: Test chagne

---

### **Unit Tests Added or Updated** (Yes / No)  
NA, this is the test change

---

### **Additional Testing Performed**
Manual test run on local macine

--- 

### **Change Behind Feature Flag** (Yes / No)
NA

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
No

---
### **Logging Added/Updated** (Yes/No)
NA 

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
